### PR TITLE
refactor(tui): decompose TUI into orchestrator + handlers + tasks

### DIFF
--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -46,6 +46,8 @@ pub enum Action {
     },
     // User cancelled the in-progress generation
     CancelGeneration,
+    // Cycle to next reasoning effort level
+    CycleEffort,
     // Replace context with a loaded session
     LoadSession(SessionData),
     // Reset to a fresh conversation
@@ -252,6 +254,11 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
             app_state.status_message = String::from("New session.");
             Effect::Render
         }
+        Action::CycleEffort => {
+            app_state.effort = app_state.effort.next();
+            app_state.status_message = format!("Reasoning: {}", app_state.effort.label());
+            Effect::Render
+        }
         // ModelsFetched is TUI-only state — core update() is a no-op.
         // The TUI event loop intercepts this before it reaches update().
         Action::ModelsFetched(_) => Effect::None,
@@ -261,7 +268,7 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::inference::{ContextItem, Source};
+    use crate::inference::{ContextItem, Effort, Source};
     use crate::test_support::test_app;
 
     #[test]
@@ -538,6 +545,18 @@ mod tests {
         assert!(app.status_message.contains("30 out"));
         assert!(app.status_message.contains("TTFT 250ms"));
         assert_eq!(effect, Effect::SaveSession);
+    }
+
+    #[test]
+    fn test_cycle_effort_advances_and_updates_status() {
+        let mut app = test_app();
+        assert_eq!(app.effort, Effort::default()); // Auto
+
+        let effect = update(&mut app, Action::CycleEffort);
+
+        assert_eq!(app.effort, Effort::Low); // Auto -> Low
+        assert!(app.status_message.contains("Low"));
+        assert_eq!(effect, Effect::Render);
     }
 
     #[test]

--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -284,8 +284,10 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
             app_state.status_message = format!("Reasoning: {}", app_state.effort.label());
             Effect::Render
         }
-        // ModelsFetched is TUI-only state — core update() is a no-op.
-        // The TUI event loop intercepts this before it reaches update().
+        // ModelsFetched carries TUI-only state (picker list). The TUI event loop
+        // intercepts this action before it reaches update(). This no-op handler
+        // exists as a defensive fallthrough — if the TUI intercept is ever removed,
+        // core silently ignores it rather than panicking on an unhandled variant.
         Action::ModelsFetched(_) => Effect::None,
     }
 }

--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -256,7 +256,8 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
         }
         Action::SessionDeleted(id) => {
             if app_state.session.current_session_id.as_deref() == Some(&id) {
-                app_state.session.current_session_id = None;
+                app_state.session = SessionState::new(&app_state.system_prompt);
+                app_state.session.status_message = String::from("Session deleted.");
             }
             Effect::Render
         }
@@ -615,13 +616,25 @@ mod tests {
     }
 
     #[test]
-    fn test_session_deleted_clears_active_session() {
+    fn test_session_deleted_resets_context_when_active() {
         let mut app = test_app();
         app.session.current_session_id = Some("sess-1".to_string());
+        app.session.context.add_user_message("hello".to_string());
+        app.session.is_loading = true;
+        app.session.session_title = "My Session".to_string();
 
         let effect = update(&mut app, Action::SessionDeleted("sess-1".to_string()));
 
+        // Full reset: context cleared, session ID gone, not loading
         assert!(app.session.current_session_id.is_none());
+        assert!(!app.session.is_loading);
+        assert!(app.session.session_title.is_empty());
+        // Only the system directive should remain
+        assert_eq!(app.session.context.items.len(), 1);
+        assert!(matches!(
+            &app.session.context.items[0],
+            ContextItem::Message(seg) if seg.source == Source::Directive
+        ));
         assert_eq!(effect, Effect::Render);
     }
 

--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -49,13 +49,21 @@ pub enum Action {
     // Cycle to next reasoning effort level
     CycleEffort,
     // Switch to a different model/provider
-    SwitchModel { name: String, provider: String },
+    SwitchModel {
+        name: String,
+        provider: String,
+    },
     // Replace context with a loaded session
     LoadSession(SessionData),
     // Reset to a fresh conversation with the given title
-    NewSession { title: String },
+    NewSession {
+        title: String,
+    },
     // Session was renamed on disk — update domain state if it's the active session
-    SessionRenamed { id: String, new_title: String },
+    SessionRenamed {
+        id: String,
+        new_title: String,
+    },
     // Session was deleted on disk — clear active session if it matches
     SessionDeleted(String),
     // Dynamic models fetched from provider APIs (handled by TUI, not core)
@@ -68,9 +76,9 @@ pub enum Effect {
     Render,
     Quit,
     SpawnRequest,
-    ExecuteTool(ToolCall),  // Run a tool asynchronously
-    SaveSession,            // Persist current session to disk
-    RebuildProvider,        // Reconstruct the provider after model switch
+    ExecuteTool(ToolCall), // Run a tool asynchronously
+    SaveSession,           // Persist current session to disk
+    RebuildProvider,       // Reconstruct the provider after model switch
 }
 
 /// Checks whether the current agentic round is fully complete (stream finished
@@ -110,10 +118,7 @@ fn check_round_complete(app_state: &mut App) -> Effect {
             Effect::SaveSession
         }
     } else if !s.pending_tool_calls.is_empty() {
-        s.status_message = format!(
-            "Waiting for {} more tool(s)...",
-            s.pending_tool_calls.len()
-        );
+        s.status_message = format!("Waiting for {} more tool(s)...", s.pending_tool_calls.len());
         Effect::Render
     } else {
         // Stream not done yet, or tools still pending — keep waiting

--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -48,6 +48,8 @@ pub enum Action {
     CancelGeneration,
     // Cycle to next reasoning effort level
     CycleEffort,
+    // Switch to a different model/provider
+    SwitchModel { name: String, provider: String },
     // Replace context with a loaded session
     LoadSession(SessionData),
     // Reset to a fresh conversation
@@ -62,8 +64,9 @@ pub enum Effect {
     Render,
     Quit,
     SpawnRequest,
-    ExecuteTool(ToolCall), // Run a tool asynchronously
-    SaveSession,           // Persist current session to disk
+    ExecuteTool(ToolCall),  // Run a tool asynchronously
+    SaveSession,            // Persist current session to disk
+    RebuildProvider,        // Reconstruct the provider after model switch
 }
 
 /// Checks whether the current agentic round is fully complete (stream finished
@@ -253,6 +256,12 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
             app_state.error = None;
             app_state.status_message = String::from("New session.");
             Effect::Render
+        }
+        Action::SwitchModel { name, provider } => {
+            app_state.status_message = format!("Switched to {} ({})", name, provider);
+            app_state.model_name = name;
+            app_state.provider_name = provider;
+            Effect::RebuildProvider
         }
         Action::CycleEffort => {
             app_state.effort = app_state.effort.next();
@@ -545,6 +554,24 @@ mod tests {
         assert!(app.status_message.contains("30 out"));
         assert!(app.status_message.contains("TTFT 250ms"));
         assert_eq!(effect, Effect::SaveSession);
+    }
+
+    #[test]
+    fn test_switch_model_updates_fields() {
+        let mut app = test_app();
+
+        let effect = update(
+            &mut app,
+            Action::SwitchModel {
+                name: "gpt-4".to_string(),
+                provider: "openrouter".to_string(),
+            },
+        );
+
+        assert_eq!(app.model_name, "gpt-4");
+        assert_eq!(app.provider_name, "openrouter");
+        assert!(app.status_message.contains("gpt-4"));
+        assert_eq!(effect, Effect::RebuildProvider);
     }
 
     #[test]

--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -52,8 +52,12 @@ pub enum Action {
     SwitchModel { name: String, provider: String },
     // Replace context with a loaded session
     LoadSession(SessionData),
-    // Reset to a fresh conversation
-    NewSession,
+    // Reset to a fresh conversation with the given title
+    NewSession { title: String },
+    // Session was renamed on disk — update domain state if it's the active session
+    SessionRenamed { id: String, new_title: String },
+    // Session was deleted on disk — clear active session if it matches
+    SessionDeleted(String),
     // Dynamic models fetched from provider APIs (handled by TUI, not core)
     ModelsFetched(Vec<ModelEntry>),
 }
@@ -241,10 +245,10 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
             app_state.status_message = format!("Loaded: {}", data.meta.title);
             Effect::Render
         }
-        Action::NewSession => {
+        Action::NewSession { title } => {
             app_state.context = Context::with_system_prompt(app_state.system_prompt.clone());
             app_state.current_session_id = None;
-            app_state.session_title = String::new();
+            app_state.session_title = title;
             app_state.is_loading = false;
             app_state.pending_tool_calls.clear();
             app_state.stream_done = false;
@@ -255,6 +259,18 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
             app_state.session_total_tokens = 0;
             app_state.error = None;
             app_state.status_message = String::from("New session.");
+            Effect::Render
+        }
+        Action::SessionRenamed { id, new_title } => {
+            if app_state.current_session_id.as_deref() == Some(&id) {
+                app_state.session_title = new_title;
+            }
+            Effect::Render
+        }
+        Action::SessionDeleted(id) => {
+            if app_state.current_session_id.as_deref() == Some(&id) {
+                app_state.current_session_id = None;
+            }
             Effect::Render
         }
         Action::SwitchModel { name, provider } => {
@@ -554,6 +570,80 @@ mod tests {
         assert!(app.status_message.contains("30 out"));
         assert!(app.status_message.contains("TTFT 250ms"));
         assert_eq!(effect, Effect::SaveSession);
+    }
+
+    #[test]
+    fn test_new_session_sets_title() {
+        let mut app = test_app();
+        app.context.add_user_message("hello".to_string());
+        app.current_session_id = Some("old-id".to_string());
+
+        let effect = update(
+            &mut app,
+            Action::NewSession {
+                title: "Session #5".to_string(),
+            },
+        );
+
+        assert_eq!(app.session_title, "Session #5");
+        assert!(app.current_session_id.is_none());
+        assert_eq!(effect, Effect::Render);
+    }
+
+    #[test]
+    fn test_session_renamed_updates_active_title() {
+        let mut app = test_app();
+        app.current_session_id = Some("sess-1".to_string());
+        app.session_title = "Old Title".to_string();
+
+        let effect = update(
+            &mut app,
+            Action::SessionRenamed {
+                id: "sess-1".to_string(),
+                new_title: "New Title".to_string(),
+            },
+        );
+
+        assert_eq!(app.session_title, "New Title");
+        assert_eq!(effect, Effect::Render);
+    }
+
+    #[test]
+    fn test_session_renamed_ignores_different_session() {
+        let mut app = test_app();
+        app.current_session_id = Some("sess-1".to_string());
+        app.session_title = "My Session".to_string();
+
+        update(
+            &mut app,
+            Action::SessionRenamed {
+                id: "sess-other".to_string(),
+                new_title: "Other Title".to_string(),
+            },
+        );
+
+        assert_eq!(app.session_title, "My Session");
+    }
+
+    #[test]
+    fn test_session_deleted_clears_active_session() {
+        let mut app = test_app();
+        app.current_session_id = Some("sess-1".to_string());
+
+        let effect = update(&mut app, Action::SessionDeleted("sess-1".to_string()));
+
+        assert!(app.current_session_id.is_none());
+        assert_eq!(effect, Effect::Render);
+    }
+
+    #[test]
+    fn test_session_deleted_ignores_different_session() {
+        let mut app = test_app();
+        app.current_session_id = Some("sess-1".to_string());
+
+        update(&mut app, Action::SessionDeleted("sess-other".to_string()));
+
+        assert_eq!(app.current_session_id.as_deref(), Some("sess-1"));
     }
 
     #[test]

--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -15,8 +15,8 @@
 
 use crate::core::config::ModelEntry;
 use crate::core::session::SessionData;
-use crate::core::state::App;
-use crate::inference::{Context, ToolCall, ToolResult, UsageStats};
+use crate::core::state::{App, SessionState};
+use crate::inference::{ToolCall, ToolResult, UsageStats};
 use log::{debug, warn};
 
 #[derive(Debug)]
@@ -80,38 +80,39 @@ pub enum Effect {
 /// the stream has finished sending all tool calls, which would prematurely fire
 /// `SpawnRequest` and re-enter the agentic loop with incomplete context.
 fn check_round_complete(app_state: &mut App) -> Effect {
-    if app_state.stream_done && app_state.pending_tool_calls.is_empty() {
-        if app_state.had_tool_calls {
+    let s = &mut app_state.session;
+    if s.stream_done && s.pending_tool_calls.is_empty() {
+        if s.had_tool_calls {
             // Tool-calling round complete — advance the agentic loop
-            app_state.agentic_rounds += 1;
+            s.agentic_rounds += 1;
             let max_rounds = app_state.max_agentic_rounds;
-            if app_state.agentic_rounds > max_rounds {
+            if s.agentic_rounds > max_rounds {
                 warn!("Agentic loop limit reached ({} rounds)", max_rounds);
-                app_state.is_loading = false;
-                app_state.error = Some(format!(
+                s.is_loading = false;
+                s.error = Some(format!(
                     "Agentic loop stopped after {} rounds. The model may be stuck in a tool-calling loop.",
                     max_rounds
                 ));
-                app_state.status_message = String::from("Loop limit reached.");
-                app_state.stream_done = false;
-                app_state.had_tool_calls = false;
+                s.status_message = String::from("Loop limit reached.");
+                s.stream_done = false;
+                s.had_tool_calls = false;
                 Effect::Render
             } else {
-                app_state.status_message = String::from("Resuming...");
-                app_state.stream_done = false;
-                app_state.had_tool_calls = false;
+                s.status_message = String::from("Resuming...");
+                s.stream_done = false;
+                s.had_tool_calls = false;
                 Effect::SpawnRequest
             }
         } else {
             // Pure text response — no tools were called
-            app_state.is_loading = false;
-            app_state.status_message = app_state.usage_stats.display_summary();
+            s.is_loading = false;
+            s.status_message = s.usage_stats.display_summary();
             Effect::SaveSession
         }
-    } else if !app_state.pending_tool_calls.is_empty() {
-        app_state.status_message = format!(
+    } else if !s.pending_tool_calls.is_empty() {
+        s.status_message = format!(
             "Waiting for {} more tool(s)...",
-            app_state.pending_tool_calls.len()
+            s.pending_tool_calls.len()
         );
         Effect::Render
     } else {
@@ -124,26 +125,28 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
     match action {
         Action::Quit => Effect::Quit,
         Action::Submit(message) => {
-            if message.is_empty() || app_state.is_loading {
+            if message.is_empty() || app_state.session.is_loading {
                 return Effect::None; // noop on empty input or if already loading
             }
-            app_state.context.add_user_message(message);
-            app_state.is_loading = true;
-            app_state.agentic_rounds = 0;
-            app_state.stream_done = false;
-            app_state.had_tool_calls = false;
-            app_state.usage_stats = UsageStats::default();
-            app_state.message_stats.clear();
-            app_state.status_message = String::from("Loading...");
+            let s = &mut app_state.session;
+            s.context.add_user_message(message);
+            s.is_loading = true;
+            s.agentic_rounds = 0;
+            s.stream_done = false;
+            s.had_tool_calls = false;
+            s.usage_stats = UsageStats::default();
+            s.message_stats.clear();
+            s.status_message = String::from("Loading...");
             Effect::SpawnRequest
         }
         Action::ResponseChunk { text, item_id } => {
             app_state
+                .session
                 .context
                 .append_to_last_model_message(&text, item_id.as_deref());
             // Log total message length after append
             if let Some(crate::inference::ContextItem::Message(last)) =
-                app_state.context.items.last()
+                app_state.session.context.items.last()
             {
                 debug!(
                     "ResponseChunk applied: chunk_len={}, total_msg_len={}",
@@ -151,28 +154,30 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
                     last.content.len()
                 );
             }
-            app_state.status_message = String::from("Receiving...");
+            app_state.session.status_message = String::from("Receiving...");
             Effect::Render
         }
         Action::ThinkingChunk { text, item_id } => {
             app_state
+                .session
                 .context
                 .append_to_last_thinking_message(&text, item_id.as_deref());
             debug!("ThinkingChunk applied: chunk_len={}", text.len());
-            app_state.status_message = String::from("Thinking...");
+            app_state.session.status_message = String::from("Thinking...");
             Effect::Render
         }
         Action::ResponseDone(stats) => {
-            app_state.context.clear_active_streams();
-            app_state.stream_done = true;
+            app_state.session.context.clear_active_streams();
+            app_state.session.stream_done = true;
             if let Some(round_stats) = stats {
-                app_state.usage_stats.accumulate(&round_stats);
+                app_state.session.usage_stats.accumulate(&round_stats);
                 // Accumulate into session-level running total
                 if let Some(tokens) = round_stats.total_tokens {
-                    app_state.session_total_tokens += tokens;
+                    app_state.session.session_total_tokens += tokens;
                 }
                 // Store per-message stats on the last Model message
                 if let Some(idx) = app_state
+                    .session
                     .context
                     .items
                     .iter()
@@ -180,11 +185,11 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
                         matches!(item, crate::inference::ContextItem::Message(seg) if seg.source == crate::inference::Source::Model)
                     })
                 {
-                    app_state.message_stats.insert(idx, round_stats);
+                    app_state.session.message_stats.insert(idx, round_stats);
                 }
             }
             if let Some(crate::inference::ContextItem::Message(last)) =
-                app_state.context.items.last()
+                app_state.session.context.items.last()
             {
                 debug!("ResponseDone: final message length={}", last.content.len());
             }
@@ -198,90 +203,72 @@ pub fn update(app_state: &mut App, action: Action) -> Effect {
                 );
                 return Effect::Render;
             }
-            app_state.had_tool_calls = true;
-            app_state
-                .pending_tool_calls
-                .insert(tool_call.call_id.clone());
-            app_state.context.add_tool_call(tool_call.clone());
-            app_state.status_message = format!("Calling: {}...", tool_call.name);
+            let s = &mut app_state.session;
+            s.had_tool_calls = true;
+            s.pending_tool_calls.insert(tool_call.call_id.clone());
+            s.context.add_tool_call(tool_call.clone());
+            s.status_message = format!("Calling: {}...", tool_call.name);
             Effect::ExecuteTool(tool_call)
         }
         Action::ToolResultReady { call_id, output } => {
-            app_state.pending_tool_calls.remove(&call_id);
+            app_state.session.pending_tool_calls.remove(&call_id);
             app_state
+                .session
                 .context
                 .add_tool_result(ToolResult { call_id, output });
             check_round_complete(app_state)
         }
         Action::CancelGeneration => {
-            app_state.is_loading = false;
-            app_state.pending_tool_calls.clear();
-            app_state.stream_done = false;
-            app_state.had_tool_calls = false;
-            app_state.usage_stats = UsageStats::default();
-            app_state.context.clear_active_streams();
-            app_state.status_message = String::from("Cancelled.");
+            let s = &mut app_state.session;
+            s.is_loading = false;
+            s.pending_tool_calls.clear();
+            s.stream_done = false;
+            s.had_tool_calls = false;
+            s.usage_stats = UsageStats::default();
+            s.context.clear_active_streams();
+            s.status_message = String::from("Cancelled.");
             Effect::Render
         }
         Action::LoadSession(data) => {
-            // Rebuild fresh context with system directive, then push loaded items
-            let mut context = Context::with_system_prompt(app_state.system_prompt.clone());
+            let mut session = SessionState::new(&app_state.system_prompt);
+            // Rebuild context with system directive, then push loaded items
             for item in data.items {
-                context.items.push(item);
+                session.context.items.push(item);
             }
-            app_state.context = context;
-            app_state.current_session_id = Some(data.meta.id);
-            app_state.session_title = data.meta.title.clone();
+            session.current_session_id = Some(data.meta.id);
+            session.session_title = data.meta.title.clone();
+            session.status_message = format!("Loaded: {}", data.meta.title);
             app_state.model_name = data.meta.model_name;
-            app_state.is_loading = false;
-            app_state.pending_tool_calls.clear();
-            app_state.stream_done = false;
-            app_state.had_tool_calls = false;
-            app_state.agentic_rounds = 0;
-            app_state.usage_stats = UsageStats::default();
-            app_state.message_stats.clear();
-            app_state.session_total_tokens = 0;
-            app_state.error = None;
-            app_state.status_message = format!("Loaded: {}", data.meta.title);
+            app_state.session = session;
             Effect::Render
         }
         Action::NewSession { title } => {
-            app_state.context = Context::with_system_prompt(app_state.system_prompt.clone());
-            app_state.current_session_id = None;
-            app_state.session_title = title;
-            app_state.is_loading = false;
-            app_state.pending_tool_calls.clear();
-            app_state.stream_done = false;
-            app_state.had_tool_calls = false;
-            app_state.agentic_rounds = 0;
-            app_state.usage_stats = UsageStats::default();
-            app_state.message_stats.clear();
-            app_state.session_total_tokens = 0;
-            app_state.error = None;
-            app_state.status_message = String::from("New session.");
+            app_state.session = SessionState::new(&app_state.system_prompt);
+            app_state.session.session_title = title;
+            app_state.session.status_message = String::from("New session.");
             Effect::Render
         }
         Action::SessionRenamed { id, new_title } => {
-            if app_state.current_session_id.as_deref() == Some(&id) {
-                app_state.session_title = new_title;
+            if app_state.session.current_session_id.as_deref() == Some(&id) {
+                app_state.session.session_title = new_title;
             }
             Effect::Render
         }
         Action::SessionDeleted(id) => {
-            if app_state.current_session_id.as_deref() == Some(&id) {
-                app_state.current_session_id = None;
+            if app_state.session.current_session_id.as_deref() == Some(&id) {
+                app_state.session.current_session_id = None;
             }
             Effect::Render
         }
         Action::SwitchModel { name, provider } => {
-            app_state.status_message = format!("Switched to {} ({})", name, provider);
+            app_state.session.status_message = format!("Switched to {} ({})", name, provider);
             app_state.model_name = name;
             app_state.provider_name = provider;
             Effect::RebuildProvider
         }
         Action::CycleEffort => {
             app_state.effort = app_state.effort.next();
-            app_state.status_message = format!("Reasoning: {}", app_state.effort.label());
+            app_state.session.status_message = format!("Reasoning: {}", app_state.effort.label());
             Effect::Render
         }
         // ModelsFetched carries TUI-only state (picker list). The TUI event loop
@@ -310,12 +297,12 @@ mod tests {
     #[test]
     fn test_submit_noop_on_empty_message() {
         let mut app = test_app();
-        let initial_context_len = app.context.items.len();
+        let initial_context_len = app.session.context.items.len();
 
         let effect = update(&mut app, Action::Submit(String::new()));
 
-        assert_eq!(app.context.items.len(), initial_context_len);
-        assert!(!app.is_loading);
+        assert_eq!(app.session.context.items.len(), initial_context_len);
+        assert!(!app.session.is_loading);
         assert_eq!(effect, Effect::None);
     }
 
@@ -325,18 +312,18 @@ mod tests {
 
         let effect = update(&mut app, Action::Submit("Hello, model!".to_string()));
 
-        assert_eq!(app.context.items.len(), 2); // System + User
+        assert_eq!(app.session.context.items.len(), 2); // System + User
         assert!(
-            matches!(&app.context.items[1], ContextItem::Message(seg) if seg.content == "Hello, model!")
+            matches!(&app.session.context.items[1], ContextItem::Message(seg) if seg.content == "Hello, model!")
         );
-        assert!(app.is_loading);
+        assert!(app.session.is_loading);
         assert_eq!(effect, Effect::SpawnRequest);
     }
 
     #[test]
     fn test_response_chunk_appends_and_updates_status() {
         let mut app = test_app();
-        app.is_loading = true;
+        app.session.is_loading = true;
 
         let effect = update(
             &mut app,
@@ -346,24 +333,24 @@ mod tests {
             },
         );
 
-        assert_eq!(app.context.items.len(), 2); // System + Model (new)
+        assert_eq!(app.session.context.items.len(), 2); // System + Model (new)
         assert!(
-            matches!(&app.context.items[1], ContextItem::Message(seg) if seg.content == "Response " && seg.source == Source::Model)
+            matches!(&app.session.context.items[1], ContextItem::Message(seg) if seg.content == "Response " && seg.source == Source::Model)
         );
-        assert!(app.is_loading);
-        assert_eq!(app.status_message, "Receiving...");
+        assert!(app.session.is_loading);
+        assert_eq!(app.session.status_message, "Receiving...");
         assert_eq!(effect, Effect::Render);
     }
 
     #[test]
     fn test_response_done_stops_loading() {
         let mut app = test_app();
-        app.is_loading = true;
+        app.session.is_loading = true;
 
         let effect = update(&mut app, Action::ResponseDone(None));
 
-        assert!(!app.is_loading);
-        assert_eq!(app.status_message, "Response complete.");
+        assert!(!app.session.is_loading);
+        assert_eq!(app.session.status_message, "Response complete.");
         assert_eq!(effect, Effect::SaveSession);
     }
 
@@ -379,23 +366,23 @@ mod tests {
     #[test]
     fn test_tool_call_received_returns_execute_effect() {
         let mut app = test_app();
-        app.is_loading = true;
+        app.session.is_loading = true;
         let tc = make_tool_call("get_weather", "call_1");
 
         let effect = update(&mut app, Action::ToolCallReceived(tc.clone()));
 
-        assert!(app.pending_tool_calls.contains("call_1"));
+        assert!(app.session.pending_tool_calls.contains("call_1"));
         assert!(matches!(effect, Effect::ExecuteTool(ref t) if t.call_id == "call_1"));
-        assert!(app.status_message.contains("get_weather"));
+        assert!(app.session.status_message.contains("get_weather"));
     }
 
     #[test]
     fn test_tool_result_ready_last_tool_spawns_request() {
         let mut app = test_app();
-        app.is_loading = true;
-        app.had_tool_calls = true;
-        app.stream_done = true; // stream already finished
-        app.pending_tool_calls.insert("call_1".to_string());
+        app.session.is_loading = true;
+        app.session.had_tool_calls = true;
+        app.session.stream_done = true; // stream already finished
+        app.session.pending_tool_calls.insert("call_1".to_string());
 
         let effect = update(
             &mut app,
@@ -405,18 +392,18 @@ mod tests {
             },
         );
 
-        assert!(app.pending_tool_calls.is_empty());
+        assert!(app.session.pending_tool_calls.is_empty());
         assert_eq!(effect, Effect::SpawnRequest);
     }
 
     #[test]
     fn test_tool_result_ready_with_remaining_tools_renders() {
         let mut app = test_app();
-        app.is_loading = true;
-        app.had_tool_calls = true;
-        app.stream_done = true;
-        app.pending_tool_calls.insert("call_1".to_string());
-        app.pending_tool_calls.insert("call_2".to_string());
+        app.session.is_loading = true;
+        app.session.had_tool_calls = true;
+        app.session.stream_done = true;
+        app.session.pending_tool_calls.insert("call_1".to_string());
+        app.session.pending_tool_calls.insert("call_2".to_string());
 
         let effect = update(
             &mut app,
@@ -426,15 +413,15 @@ mod tests {
             },
         );
 
-        assert_eq!(app.pending_tool_calls.len(), 1);
+        assert_eq!(app.session.pending_tool_calls.len(), 1);
         assert_eq!(effect, Effect::Render);
-        assert!(app.status_message.contains("1 more"));
+        assert!(app.session.status_message.contains("1 more"));
     }
 
     #[test]
     fn test_tool_call_with_empty_call_id_is_skipped() {
         let mut app = test_app();
-        app.is_loading = true;
+        app.session.is_loading = true;
         let tc = ToolCall {
             id: "fc_1".into(),
             call_id: String::new(),
@@ -443,17 +430,17 @@ mod tests {
         };
         let effect = update(&mut app, Action::ToolCallReceived(tc));
         assert_eq!(effect, Effect::Render);
-        assert!(app.pending_tool_calls.is_empty());
+        assert!(app.session.pending_tool_calls.is_empty());
     }
 
     #[test]
     fn test_agentic_loop_bound_enforced() {
         let mut app = test_app();
-        app.is_loading = true;
-        app.had_tool_calls = true;
-        app.stream_done = true;
-        app.agentic_rounds = app.max_agentic_rounds;
-        app.pending_tool_calls.insert("call_1".to_string());
+        app.session.is_loading = true;
+        app.session.had_tool_calls = true;
+        app.session.stream_done = true;
+        app.session.agentic_rounds = app.max_agentic_rounds;
+        app.session.pending_tool_calls.insert("call_1".to_string());
 
         let effect = update(
             &mut app,
@@ -464,32 +451,32 @@ mod tests {
         );
 
         assert_eq!(effect, Effect::Render);
-        assert!(!app.is_loading);
-        assert!(app.error.is_some());
-        assert!(app.error.as_ref().unwrap().contains("loop"));
+        assert!(!app.session.is_loading);
+        assert!(app.session.error.is_some());
+        assert!(app.session.error.as_ref().unwrap().contains("loop"));
     }
 
     #[test]
     fn test_agentic_rounds_reset_on_submit() {
         let mut app = test_app();
-        app.agentic_rounds = 5;
+        app.session.agentic_rounds = 5;
 
         update(&mut app, Action::Submit("hello".to_string()));
 
-        assert_eq!(app.agentic_rounds, 0);
+        assert_eq!(app.session.agentic_rounds, 0);
     }
 
     #[test]
     fn test_response_done_stays_loading_when_tools_pending() {
         let mut app = test_app();
-        app.is_loading = true;
-        app.had_tool_calls = true;
-        app.pending_tool_calls.insert("call_1".to_string());
+        app.session.is_loading = true;
+        app.session.had_tool_calls = true;
+        app.session.pending_tool_calls.insert("call_1".to_string());
 
         let effect = update(&mut app, Action::ResponseDone(None));
 
-        assert!(app.is_loading); // Still loading — tools not done yet
-        assert!(app.stream_done);
+        assert!(app.session.is_loading); // Still loading — tools not done yet
+        assert!(app.session.stream_done);
         assert_eq!(effect, Effect::Render);
     }
 
@@ -498,13 +485,13 @@ mod tests {
     #[test]
     fn test_tool_result_before_stream_done_does_not_spawn() {
         let mut app = test_app();
-        app.is_loading = true;
+        app.session.is_loading = true;
 
         // Stream sends first tool call
         let tc1 = make_tool_call("add", "call_1");
         let effect = update(&mut app, Action::ToolCallReceived(tc1));
         assert!(matches!(effect, Effect::ExecuteTool(_)));
-        assert!(app.had_tool_calls);
+        assert!(app.session.had_tool_calls);
 
         // Tool executes fast and returns before stream is done
         let effect = update(
@@ -516,7 +503,7 @@ mod tests {
         );
         // Should NOT fire SpawnRequest — stream_done is still false
         assert_eq!(effect, Effect::Render);
-        assert!(app.is_loading);
+        assert!(app.session.is_loading);
 
         // Stream sends second tool call
         let tc2 = make_tool_call("subtract", "call_2");
@@ -526,7 +513,7 @@ mod tests {
         // Stream finishes — but call_2 is still pending
         let effect = update(&mut app, Action::ResponseDone(None));
         assert_eq!(effect, Effect::Render);
-        assert!(app.is_loading);
+        assert!(app.session.is_loading);
 
         // Second tool completes — NOW we can spawn
         let effect = update(
@@ -542,20 +529,20 @@ mod tests {
     #[test]
     fn test_submit_resets_stream_flags() {
         let mut app = test_app();
-        app.stream_done = true;
-        app.had_tool_calls = true;
+        app.session.stream_done = true;
+        app.session.had_tool_calls = true;
 
         update(&mut app, Action::Submit("hello".to_string()));
 
-        assert!(!app.stream_done);
-        assert!(!app.had_tool_calls);
-        assert_eq!(app.agentic_rounds, 0);
+        assert!(!app.session.stream_done);
+        assert!(!app.session.had_tool_calls);
+        assert_eq!(app.session.agentic_rounds, 0);
     }
 
     #[test]
     fn test_response_done_with_stats_updates_status() {
         let mut app = test_app();
-        app.is_loading = true;
+        app.session.is_loading = true;
 
         let stats = UsageStats {
             input_tokens: Some(100),
@@ -567,18 +554,18 @@ mod tests {
         };
         let effect = update(&mut app, Action::ResponseDone(Some(stats)));
 
-        assert!(!app.is_loading);
-        assert!(app.status_message.contains("100 in"));
-        assert!(app.status_message.contains("30 out"));
-        assert!(app.status_message.contains("TTFT 250ms"));
+        assert!(!app.session.is_loading);
+        assert!(app.session.status_message.contains("100 in"));
+        assert!(app.session.status_message.contains("30 out"));
+        assert!(app.session.status_message.contains("TTFT 250ms"));
         assert_eq!(effect, Effect::SaveSession);
     }
 
     #[test]
     fn test_new_session_sets_title() {
         let mut app = test_app();
-        app.context.add_user_message("hello".to_string());
-        app.current_session_id = Some("old-id".to_string());
+        app.session.context.add_user_message("hello".to_string());
+        app.session.current_session_id = Some("old-id".to_string());
 
         let effect = update(
             &mut app,
@@ -587,16 +574,16 @@ mod tests {
             },
         );
 
-        assert_eq!(app.session_title, "Session #5");
-        assert!(app.current_session_id.is_none());
+        assert_eq!(app.session.session_title, "Session #5");
+        assert!(app.session.current_session_id.is_none());
         assert_eq!(effect, Effect::Render);
     }
 
     #[test]
     fn test_session_renamed_updates_active_title() {
         let mut app = test_app();
-        app.current_session_id = Some("sess-1".to_string());
-        app.session_title = "Old Title".to_string();
+        app.session.current_session_id = Some("sess-1".to_string());
+        app.session.session_title = "Old Title".to_string();
 
         let effect = update(
             &mut app,
@@ -606,15 +593,15 @@ mod tests {
             },
         );
 
-        assert_eq!(app.session_title, "New Title");
+        assert_eq!(app.session.session_title, "New Title");
         assert_eq!(effect, Effect::Render);
     }
 
     #[test]
     fn test_session_renamed_ignores_different_session() {
         let mut app = test_app();
-        app.current_session_id = Some("sess-1".to_string());
-        app.session_title = "My Session".to_string();
+        app.session.current_session_id = Some("sess-1".to_string());
+        app.session.session_title = "My Session".to_string();
 
         update(
             &mut app,
@@ -624,28 +611,28 @@ mod tests {
             },
         );
 
-        assert_eq!(app.session_title, "My Session");
+        assert_eq!(app.session.session_title, "My Session");
     }
 
     #[test]
     fn test_session_deleted_clears_active_session() {
         let mut app = test_app();
-        app.current_session_id = Some("sess-1".to_string());
+        app.session.current_session_id = Some("sess-1".to_string());
 
         let effect = update(&mut app, Action::SessionDeleted("sess-1".to_string()));
 
-        assert!(app.current_session_id.is_none());
+        assert!(app.session.current_session_id.is_none());
         assert_eq!(effect, Effect::Render);
     }
 
     #[test]
     fn test_session_deleted_ignores_different_session() {
         let mut app = test_app();
-        app.current_session_id = Some("sess-1".to_string());
+        app.session.current_session_id = Some("sess-1".to_string());
 
         update(&mut app, Action::SessionDeleted("sess-other".to_string()));
 
-        assert_eq!(app.current_session_id.as_deref(), Some("sess-1"));
+        assert_eq!(app.session.current_session_id.as_deref(), Some("sess-1"));
     }
 
     #[test]
@@ -662,7 +649,7 @@ mod tests {
 
         assert_eq!(app.model_name, "gpt-4");
         assert_eq!(app.provider_name, "openrouter");
-        assert!(app.status_message.contains("gpt-4"));
+        assert!(app.session.status_message.contains("gpt-4"));
         assert_eq!(effect, Effect::RebuildProvider);
     }
 
@@ -674,26 +661,26 @@ mod tests {
         let effect = update(&mut app, Action::CycleEffort);
 
         assert_eq!(app.effort, Effort::Low); // Auto -> Low
-        assert!(app.status_message.contains("Low"));
+        assert!(app.session.status_message.contains("Low"));
         assert_eq!(effect, Effect::Render);
     }
 
     #[test]
     fn test_submit_resets_usage_stats() {
         let mut app = test_app();
-        app.usage_stats.input_tokens = Some(500);
-        app.usage_stats.output_tokens = Some(100);
+        app.session.usage_stats.input_tokens = Some(500);
+        app.session.usage_stats.output_tokens = Some(100);
 
         update(&mut app, Action::Submit("hello".to_string()));
 
-        assert!(app.usage_stats.input_tokens.is_none());
-        assert!(app.usage_stats.output_tokens.is_none());
+        assert!(app.session.usage_stats.input_tokens.is_none());
+        assert!(app.session.usage_stats.output_tokens.is_none());
     }
 
     #[test]
     fn test_stats_accumulate_across_agentic_rounds() {
         let mut app = test_app();
-        app.is_loading = true;
+        app.session.is_loading = true;
 
         // Round 1: tool-calling round
         let tc = make_tool_call("add", "call_1");
@@ -728,13 +715,13 @@ mod tests {
         update(&mut app, Action::ResponseDone(Some(round2_stats)));
 
         // Tokens should be summed
-        assert_eq!(app.usage_stats.input_tokens, Some(250));
-        assert_eq!(app.usage_stats.output_tokens, Some(50));
+        assert_eq!(app.session.usage_stats.input_tokens, Some(250));
+        assert_eq!(app.session.usage_stats.output_tokens, Some(50));
         // First TTFT preserved
-        assert_eq!(app.usage_stats.ttft_ms, Some(300));
+        assert_eq!(app.session.usage_stats.ttft_ms, Some(300));
         // Durations summed
-        assert_eq!(app.usage_stats.generation_duration_ms, Some(2000));
+        assert_eq!(app.session.usage_stats.generation_duration_ms, Some(2000));
         // Status should show the summary
-        assert!(app.status_message.contains("250 in"));
+        assert!(app.session.status_message.contains("250 in"));
     }
 }

--- a/src/core/session.rs
+++ b/src/core/session.rs
@@ -250,7 +250,7 @@ pub fn load_index() -> io::Result<SessionIndex> {
 /// Skips empty sessions (no user/model messages). This is the single entry
 /// point for session persistence — call from the TUI on SaveSession effect or quit.
 pub fn save_current_session(app: &mut App) {
-    let has_messages = app.context.items.iter().any(|item| {
+    let has_messages = app.session.context.items.iter().any(|item| {
         matches!(item, ContextItem::Message(seg) if matches!(seg.source, Source::User | Source::Model))
     });
     if !has_messages {
@@ -258,11 +258,12 @@ pub fn save_current_session(app: &mut App) {
     }
 
     // Generate title if not yet assigned (e.g. dismissed session manager on startup)
-    if app.session_title.is_empty() {
-        app.session_title = format!("Session #{}", next_session_number());
+    if app.session.session_title.is_empty() {
+        app.session.session_title = format!("Session #{}", next_session_number());
     }
 
     let id = app
+        .session
         .current_session_id
         .get_or_insert_with(new_session_id)
         .clone();
@@ -272,9 +273,9 @@ pub fn save_current_session(app: &mut App) {
 
     if let Err(e) = save_session(
         &id,
-        &app.context.items,
+        &app.session.context.items,
         &app.model_name,
-        &app.session_title,
+        &app.session.session_title,
         existing_meta.as_ref(),
     ) {
         warn!("Failed to save session: {}", e);

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -5,23 +5,12 @@
 //!
 //! ```text
 //! App
-//! ├── provider: Arc<dyn CompletionProvider>  // LLM provider
-//! ├── context: Context              // conversation history
-//! ├── status_message: String        // status bar text
-//! ├── model_name: String            // current model
-//! ├── is_loading: bool              // waiting for API
-//! ├── effort: Effort                // reasoning effort level
-//! ├── error: Option<String>         // error message
-//! ├── registry: Arc<ToolRegistry>   // tool registry
-//! ├── pending_tool_calls: HashSet   // call_ids awaiting results
-//! ├── agentic_rounds: u8           // loop iteration counter
-//! ├── stream_done: bool            // SSE stream finished
-//! ├── had_tool_calls: bool         // tool calls received this round
-//! ├── usage_stats: UsageStats     // accumulated inference metrics
-//! ├── message_stats: HashMap      // per-message stats keyed by item index
-//! ├── provider_name: String       // active provider ("openrouter", "lmstudio")
-//! ├── session_total_tokens: u32   // running total across all submissions
-//! └── session_title: String       // display title ("Session #3" or custom)
+//! ├── provider: Arc<dyn CompletionProvider>  // LLM provider (config lifetime)
+//! ├── session: SessionState                  // per-conversation state
+//! ├── effort: Effort                         // reasoning effort level
+//! ├── registry: Arc<ToolRegistry>            // tool registry
+//! ├── provider_name: String                  // active provider name
+//! └── ... config-driven fields ...
 //! ```
 //!
 //! State changes only happen through `update(state, action)` in action.rs.
@@ -35,34 +24,54 @@ use crate::inference::{CompletionProvider, Context, Effort, ToolDefinition, Usag
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+/// Per-session state that gets fully replaced on NewSession / LoadSession.
+///
+/// Extracting this from App means session resets are a single assignment
+/// instead of resetting 13 fields individually.
+pub struct SessionState {
+    pub context: Context,
+    pub current_session_id: Option<String>,
+    pub session_title: String,
+    pub is_loading: bool,
+    pub pending_tool_calls: HashSet<String>,
+    pub stream_done: bool,
+    pub had_tool_calls: bool,
+    pub agentic_rounds: u8,
+    pub usage_stats: UsageStats,
+    pub message_stats: HashMap<usize, UsageStats>,
+    pub session_total_tokens: u32,
+    pub error: Option<String>,
+    pub status_message: String,
+}
+
+impl SessionState {
+    pub fn new(system_prompt: &str) -> Self {
+        Self {
+            context: Context::with_system_prompt(system_prompt.to_string()),
+            current_session_id: None,
+            session_title: String::new(),
+            is_loading: false,
+            pending_tool_calls: HashSet::new(),
+            stream_done: false,
+            had_tool_calls: false,
+            agentic_rounds: 0,
+            usage_stats: UsageStats::default(),
+            message_stats: HashMap::new(),
+            session_total_tokens: 0,
+            error: None,
+            status_message: String::from("Welcome to Navi!"),
+        }
+    }
+}
+
 pub struct App {
     pub provider: Arc<dyn CompletionProvider>,
-    pub context: Context,
-    pub status_message: String,
-    pub model_name: String,
-    pub is_loading: bool,
+    pub session: SessionState,
     pub effort: Effort,
-    pub error: Option<String>,
     pub registry: Arc<ToolRegistry>,
-    pub pending_tool_calls: HashSet<String>, // call_ids awaiting results
-    pub agentic_rounds: u8,
-    /// True after `ResponseDone` — the SSE stream has finished sending events.
-    pub stream_done: bool,
-    /// True if any `ToolCallReceived` arrived this round.
-    pub had_tool_calls: bool,
-    /// Accumulated usage stats for the current submission (across agentic rounds).
-    pub usage_stats: UsageStats,
-    /// Per-message usage stats, keyed by context item index.
-    /// Each model message gets the stats from its agentic round.
-    pub message_stats: HashMap<usize, UsageStats>,
-    /// Active session ID (None = unsaved new session).
-    pub current_session_id: Option<String>,
+    pub model_name: String,
     /// Provider name for the active model (e.g. "openrouter", "lmstudio").
     pub provider_name: String,
-    /// Running total of tokens across all submissions in this session.
-    pub session_total_tokens: u32,
-    /// Display title for the current session (e.g. "Session #3" or user-renamed).
-    pub session_title: String,
 
     // --- Config-driven fields ---
     pub max_agentic_rounds: u8,
@@ -80,23 +89,11 @@ impl App {
     pub fn new(provider: Arc<dyn CompletionProvider>, model_name: String) -> Self {
         Self {
             provider,
-            context: Context::new(),
-            status_message: String::from("Welcome to Navi!"),
+            session: SessionState::new(config::DEFAULT_SYSTEM_PROMPT),
             model_name,
-            is_loading: false,
             effort: Effort::default(),
-            error: None,
             registry: Arc::new(crate::core::tools::default_registry()),
-            pending_tool_calls: HashSet::new(),
-            agentic_rounds: 0,
-            stream_done: false,
-            had_tool_calls: false,
-            usage_stats: UsageStats::default(),
-            message_stats: HashMap::new(),
-            current_session_id: None,
             provider_name: String::new(),
-            session_total_tokens: 0,
-            session_title: String::new(),
             max_agentic_rounds: DEFAULT_MAX_AGENTIC_ROUNDS,
             max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
             system_prompt: config::DEFAULT_SYSTEM_PROMPT.to_string(),
@@ -111,23 +108,11 @@ impl App {
     pub fn from_config(provider: Arc<dyn CompletionProvider>, config: &ResolvedConfig) -> Self {
         Self {
             provider,
-            context: Context::with_system_prompt(config.system_prompt.clone()),
-            status_message: String::from("Welcome to Navi!"),
+            session: SessionState::new(&config.system_prompt),
             model_name: config.model_name.clone(),
-            is_loading: false,
             effort: config.effort,
-            error: None,
             registry: Arc::new(crate::core::tools::default_registry()),
-            pending_tool_calls: HashSet::new(),
-            agentic_rounds: 0,
-            stream_done: false,
-            had_tool_calls: false,
-            usage_stats: UsageStats::default(),
-            message_stats: HashMap::new(),
-            current_session_id: None,
             provider_name: config.provider.clone(),
-            session_total_tokens: 0,
-            session_title: String::new(),
             max_agentic_rounds: config.max_agentic_rounds,
             max_output_tokens: config.max_output_tokens,
             system_prompt: config.system_prompt.clone(),
@@ -150,8 +135,8 @@ mod tests {
     #[test]
     fn test_app_new_defaults() {
         let app = test_app();
-        assert_eq!(app.status_message, "Welcome to Navi!");
-        assert!(!app.is_loading);
+        assert_eq!(app.session.status_message, "Welcome to Navi!");
+        assert!(!app.session.is_loading);
         assert_eq!(app.model_name, "test-model");
     }
 }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -16,9 +16,9 @@
 //! State changes only happen through `update(state, action)` in action.rs.
 //! This keeps things predictable, so no surprise mutations.
 
-use crate::core::config::{ModelEntry, ResolvedConfig};
 #[cfg(test)]
 use crate::core::config::{self, DEFAULT_MAX_AGENTIC_ROUNDS, DEFAULT_MAX_OUTPUT_TOKENS};
+use crate::core::config::{ModelEntry, ResolvedConfig};
 use crate::core::tools::ToolRegistry;
 use crate::inference::{CompletionProvider, Context, Effort, ToolDefinition, UsageStats};
 use std::collections::{HashMap, HashSet};

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -3,9 +3,31 @@ pub mod provider;
 pub mod providers;
 pub mod types;
 
+use std::sync::Arc;
+
+use crate::core::config::ResolvedConfig;
+
 pub use provider::{CompletionProvider, CompletionRequest, ProviderError};
 pub use providers::{LmStudioProvider, OpenRouterProvider};
 pub use types::{
     Context, ContextItem, ContextSegment, Effort, Source, StreamChunk, ToolCall, ToolDefinition,
     ToolResult, UsageStats,
 };
+
+/// Build a provider from a resolved config's provider name and credentials.
+pub fn build_provider(config: &ResolvedConfig) -> Arc<dyn CompletionProvider> {
+    match config.provider.as_str() {
+        "lmstudio" => Arc::new(LmStudioProvider::new(config.lmstudio_base_url.clone())),
+        _ => {
+            // Default to openrouter
+            let api_key = config
+                .openrouter_api_key
+                .clone()
+                .expect("OpenRouter API key must be set (config file, OPENROUTER_API_KEY env var, or --provider lmstudio)");
+            Arc::new(OpenRouterProvider::new(
+                api_key,
+                Some(config.openrouter_base_url.clone()),
+            ))
+        }
+    }
+}

--- a/src/inference/types.rs
+++ b/src/inference/types.rs
@@ -215,6 +215,13 @@ impl Context {
         }
     }
 
+    /// Returns true if any User or Model messages exist in the context.
+    pub fn has_visible_messages(&self) -> bool {
+        self.items.iter().any(|item| {
+            matches!(item, ContextItem::Message(seg) if matches!(seg.source, Source::User | Source::Model))
+        })
+    }
+
     /// Clears the active stream routing map. Called when a response completes.
     pub fn clear_active_streams(&mut self) {
         self.active_streams.clear();

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -11,12 +11,17 @@
 //! Simple display components that receive all data as parameters:
 //! - `TitleBar`: Top status bar showing model name and status
 //! - `Message`: Individual conversation message rendering
+//! - `LandingPage`: Welcome screen when no messages exist
+//! - `Logo`: ASCII art logo rendering
+//! - `ToolMessage`: Tool call/result display
 //!
 //! ### Stateful Components (Event-Driven)
 //!
 //! Components that manage local state and emit events:
 //! - `InputBox`: Text input field with effort level indicator
 //! - `MessageList`: Scrollable conversation view with layout caching
+//! - `SessionManager`: Session list overlay with create/rename/delete
+//! - `ModelPicker`: Fuzzy-search model selection overlay
 //!
 //! ## Design Philosophy
 //!
@@ -57,26 +62,20 @@
 //!
 //! ```text
 //! components/
-//! ├── mod.rs           (this file)
-//! ├── title_bar.rs     (Top status bar)
-//! ├── message.rs       (Single message renderer)
-//! ├── message_list.rs  (Scrollable message container)
-//! └── input_box/       (Text input with effort indicator)
+//! ├── mod.rs            (this file)
+//! ├── title_bar.rs      (Top status bar)
+//! ├── message.rs        (Single message renderer)
+//! ├── message_list.rs   (Scrollable message container)
+//! ├── input_box/        (Text input with effort indicator)
+//! ├── tool_message.rs   (Tool call/result display)
+//! ├── landing.rs        (Welcome/landing page)
+//! ├── logo.rs           (ASCII art logo)
+//! ├── session_manager.rs(Session list overlay)
+//! └── model_picker.rs   (Model selection overlay)
 //! ```
-//!
-//! ## Migration Status
-//!
-//! Components will be migrated from the monolithic `ui.rs` module incrementally:
-//!
-//! - [ ] Phase 1: Infrastructure (component.rs, this file)
-//! - [ ] Phase 2: TitleBar, Message (stateless)
-//! - [ ] Phase 3: InputBox, MessageList (stateful)
-//! - [ ] Phase 4: Integration (wire up in main loop)
-//! - [ ] Phase 5: Cleanup (remove old code from ui.rs)
 
 // Re-export components
 mod title_bar;
-#[allow(unused_imports)] // Used in Phase 4 (integration with main loop)
 pub use title_bar::TitleBar;
 
 pub mod input_box;

--- a/src/tui/components/session_manager.rs
+++ b/src/tui/components/session_manager.rs
@@ -60,10 +60,7 @@ impl SessionManagerState {
                         let id = self.sessions[self.selected].id.clone();
                         self.sessions[self.selected].title = new_title.clone();
                         self.rename = None;
-                        return Some(SessionEvent::Rename {
-                            id,
-                            new_title,
-                        });
+                        return Some(SessionEvent::Rename { id, new_title });
                     }
                     self.rename = None;
                 }
@@ -94,7 +91,10 @@ impl SessionManagerState {
                 }
                 TuiEvent::CursorRight => {
                     if rs.cursor < rs.buffer.len() {
-                        rs.cursor += rs.buffer[rs.cursor..].chars().next().map_or(0, |c| c.len_utf8());
+                        rs.cursor += rs.buffer[rs.cursor..]
+                            .chars()
+                            .next()
+                            .map_or(0, |c| c.len_utf8());
                     }
                 }
                 _ => {}
@@ -255,9 +255,7 @@ impl<'a> SessionManager<'a> {
                     let cursor_in_title = rs.cursor.min(title_width);
                     let cursor_x = overlay.x + 2 + date.len() as u16 + 2 + cursor_in_title as u16;
                     // overlay.y + 1(border) + row index (relative to list scroll)
-                    let visible_row = i.saturating_sub(
-                        self.state.list_state.offset(),
-                    );
+                    let visible_row = i.saturating_sub(self.state.list_state.offset());
                     let cursor_y = overlay.y + 1 + visible_row as u16;
                     rename_cursor_pos = Some((cursor_x, cursor_y));
 

--- a/src/tui/components/title_bar.rs
+++ b/src/tui/components/title_bar.rs
@@ -131,9 +131,7 @@ mod tests {
     fn render(width: u16, bar: &mut TitleBar) -> String {
         let backend = TestBackend::new(width, 1);
         let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|f| bar.render(f, f.area()))
-            .unwrap();
+        terminal.draw(|f| bar.render(f, f.area())).unwrap();
         terminal
             .backend()
             .buffer()

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -1,0 +1,386 @@
+//! Event dispatch and effect processing, extracted from the main event loop.
+
+use log::{debug, info, warn};
+use std::sync::mpsc;
+
+use ratatui::layout::Rect;
+
+use crate::core::action::{Action, Effect, update};
+use crate::core::config::ResolvedConfig;
+use crate::core::session;
+use crate::core::state::App;
+use crate::inference::ContextItem;
+use crate::tui::component::EventHandler;
+use crate::tui::components::model_picker::ModelPickerEvent;
+use crate::tui::components::session_manager::SessionEvent;
+use crate::tui::components::{InputEvent, MessageListState, ModelPickerState, SessionManagerState};
+use crate::tui::event::TuiEvent;
+use crate::tui::{InputMode, TuiState, tasks, ui};
+
+/// Dispatch a single TuiEvent. Returns true if the app should quit.
+pub fn handle_event(
+    event: TuiEvent,
+    app: &mut App,
+    tui: &mut TuiState,
+    config: &ResolvedConfig,
+    tx: &mpsc::Sender<Action>,
+    frame_area: Rect,
+) -> bool {
+    if matches!(event, TuiEvent::Resize) {
+        return false;
+    }
+
+    if matches!(event, TuiEvent::ForceQuit) {
+        return update(app, Action::Quit) == Effect::Quit;
+    }
+
+    if matches!(event, TuiEvent::OpenSessionManager) {
+        let index = session::load_index().unwrap_or_default();
+        tui.session_manager = Some(SessionManagerState::new(index.sessions));
+        return false;
+    }
+
+    if matches!(event, TuiEvent::OpenModelPicker) {
+        let mut picker = ModelPickerState::new(app.available_models.clone());
+        if let Some(ref models) = tui.fetched_models {
+            picker.set_fetched_models(models.clone());
+        }
+        tui.model_picker = Some(picker);
+        return false;
+    }
+
+    if tui.model_picker.is_some() {
+        return handle_model_picker_event(&event, app, tui, config);
+    }
+
+    if tui.session_manager.is_some() {
+        return handle_session_event(&event, app, tui);
+    }
+
+    if let TuiEvent::MouseMove(_col, row) = event {
+        handle_mouse_move(row, app, tui, frame_area);
+        return false;
+    }
+
+    if let TuiEvent::MouseClick(_col, row) = event {
+        handle_mouse_click(row, app, tui, frame_area);
+        return false;
+    }
+
+    if matches!(
+        event,
+        TuiEvent::ScrollUp | TuiEvent::ScrollDown | TuiEvent::ScrollPageUp | TuiEvent::ScrollPageDown
+    ) {
+        tui.message_list.handle_event(&event);
+        return false;
+    }
+
+    match tui.input_mode {
+        InputMode::Input => handle_input_mode(&event, app, tui, tx),
+        InputMode::Cursor => handle_cursor_mode(&event, app, tui, tx),
+    }
+}
+
+/// Drain the background action channel. Returns (should_quit, had_actions).
+pub fn process_background_actions(
+    rx: &mpsc::Receiver<Action>,
+    app: &mut App,
+    tui: &mut TuiState,
+    tx: &mpsc::Sender<Action>,
+) -> (bool, bool) {
+    let mut had_actions = false;
+    while let Ok(action) = rx.try_recv() {
+        had_actions = true;
+
+        // Intercept ModelsFetched — TUI-only state, not core business logic
+        if let Action::ModelsFetched(models) = action {
+            debug!("Received {} fetched models", models.len());
+            tui.fetched_models = Some(models.clone());
+            if let Some(ref mut mp) = tui.model_picker {
+                mp.set_fetched_models(models);
+            }
+            continue;
+        }
+
+        debug!("Event loop received: {:?}", action);
+        let effect = update(app, action);
+        match effect {
+            Effect::Quit => return (true, had_actions),
+            Effect::SpawnRequest => {
+                tui.active_abort_handles = tasks::spawn_request(app, tx.clone());
+            }
+            Effect::ExecuteTool(tool_call) => {
+                tasks::spawn_tool_execution(tool_call, app.registry.clone(), tx.clone());
+            }
+            Effect::SaveSession => {
+                session::save_current_session(app);
+            }
+            Effect::RebuildProvider => {
+                warn!("Unexpected RebuildProvider from background action");
+            }
+            _ => {}
+        }
+    }
+    (false, had_actions)
+}
+
+// --- Private helpers ---
+
+/// Cancel in-progress generation: abort tasks and dispatch CancelGeneration.
+/// Returns true if the app should quit.
+fn try_cancel_generation(app: &mut App, tui: &mut TuiState) -> bool {
+    for handle in tui.active_abort_handles.drain(..) {
+        handle.abort();
+    }
+    update(app, Action::CancelGeneration) == Effect::Quit
+}
+
+fn handle_input_mode(
+    event: &TuiEvent,
+    app: &mut App,
+    tui: &mut TuiState,
+    tx: &mpsc::Sender<Action>,
+) -> bool {
+    // Esc while loading → cancel generation
+    if matches!(event, TuiEvent::Escape) && app.session.is_loading {
+        return try_cancel_generation(app, tui);
+    }
+    // Esc → switch to Cursor mode
+    if matches!(event, TuiEvent::Escape) {
+        tui.input_mode = InputMode::Cursor;
+        // Select the last non-ToolResult item
+        let items = &app.session.context.items;
+        let mut idx = items.len();
+        while idx > 0 {
+            idx -= 1;
+            if !matches!(items[idx], ContextItem::ToolResult(_)) {
+                break;
+            }
+        }
+        tui.message_list.selected_index = if !items.is_empty() { Some(idx) } else { None };
+        return false;
+    }
+
+    if let Some(input_event) = tui.input_box.handle_event(event) {
+        match input_event {
+            InputEvent::Submit(text) => {
+                if !app.session.is_loading {
+                    let effect = update(app, Action::Submit(text));
+                    if effect == Effect::SpawnRequest {
+                        tui.active_abort_handles = tasks::spawn_request(app, tx.clone());
+                    }
+                }
+            }
+            InputEvent::CycleEffort => {
+                return update(app, Action::CycleEffort) == Effect::Quit;
+            }
+            InputEvent::ContentChanged => {}
+        }
+    }
+    false
+}
+
+fn handle_cursor_mode(
+    event: &TuiEvent,
+    app: &mut App,
+    tui: &mut TuiState,
+    tx: &mpsc::Sender<Action>,
+) -> bool {
+    let _ = tx; // unused here but kept for symmetry with handle_input_mode
+    match event {
+        TuiEvent::Escape if app.session.is_loading => try_cancel_generation(app, tui),
+        TuiEvent::Escape => false,
+        TuiEvent::InputChar(' ') => {
+            if let Some(idx) = tui.message_list.selected_index
+                && matches!(
+                    app.session.context.items.get(idx),
+                    Some(ContextItem::ToolCall(_))
+                )
+                && !tui.message_list.expanded_indices.remove(&idx)
+            {
+                tui.message_list.expanded_indices.insert(idx);
+            }
+            false
+        }
+        TuiEvent::InputChar(_) | TuiEvent::Paste(_) => {
+            tui.input_mode = InputMode::Input;
+            tui.message_list.selected_index = None;
+            tui.input_box.handle_event(event);
+            false
+        }
+        TuiEvent::Submit => {
+            tui.input_mode = InputMode::Input;
+            tui.message_list.selected_index = None;
+            false
+        }
+        TuiEvent::CursorUp => {
+            navigate_messages_up(app, tui);
+            false
+        }
+        TuiEvent::CursorDown => {
+            navigate_messages_down(app, tui);
+            false
+        }
+        TuiEvent::CycleEffort => update(app, Action::CycleEffort) == Effect::Quit,
+        _ => false,
+    }
+}
+
+fn navigate_messages_up(app: &App, tui: &mut TuiState) {
+    let items = &app.session.context.items;
+    if !items.is_empty() {
+        let mut idx = tui
+            .message_list
+            .selected_index
+            .map(|i| i.saturating_sub(1))
+            .unwrap_or(items.len() - 1);
+        while idx > 0 && matches!(items[idx], ContextItem::ToolResult(_)) {
+            idx -= 1;
+        }
+        tui.message_list.selected_index = Some(idx);
+        tui.message_list.scroll_to_selected();
+    }
+}
+
+fn navigate_messages_down(app: &App, tui: &mut TuiState) {
+    let items = &app.session.context.items;
+    if let Some(mut idx) = tui.message_list.selected_index
+        && idx + 1 < items.len()
+    {
+        idx += 1;
+        while idx < items.len() && matches!(items[idx], ContextItem::ToolResult(_)) {
+            idx += 1;
+        }
+        if idx < items.len() {
+            tui.message_list.selected_index = Some(idx);
+            tui.message_list.scroll_to_selected();
+        }
+    }
+}
+
+fn handle_mouse_move(row: u16, _app: &App, tui: &mut TuiState, frame_area: Rect) {
+    let scroll_offset = tui.message_list.scroll_state.offset().y;
+    let input_height = tui.input_box.calculate_height(frame_area.width);
+    tui.message_list.selected_index = ui::hit_test_message(
+        row,
+        frame_area,
+        scroll_offset,
+        &tui.message_list.layout.prefix_heights,
+        input_height,
+    );
+}
+
+fn handle_mouse_click(row: u16, app: &App, tui: &mut TuiState, frame_area: Rect) {
+    let scroll_offset = tui.message_list.scroll_state.offset().y;
+    let input_height = tui.input_box.calculate_height(frame_area.width);
+    let hit = ui::hit_test_message(
+        row,
+        frame_area,
+        scroll_offset,
+        &tui.message_list.layout.prefix_heights,
+        input_height,
+    );
+    if let Some(idx) = hit {
+        tui.message_list.selected_index = Some(idx);
+        if matches!(app.session.context.items.get(idx), Some(ContextItem::ToolCall(_)))
+            && !tui.message_list.expanded_indices.remove(&idx)
+        {
+            tui.message_list.expanded_indices.insert(idx);
+        }
+    }
+}
+
+fn handle_session_event(event: &TuiEvent, app: &mut App, tui: &mut TuiState) -> bool {
+    let sm = tui.session_manager.as_mut().unwrap();
+    if let Some(session_event) = sm.handle_event(event) {
+        match session_event {
+            SessionEvent::Load(id) => {
+                match session::load_session(&id) {
+                    Ok(data) => {
+                        let effect = update(app, Action::LoadSession(data));
+                        if effect == Effect::Quit {
+                            tui.session_manager = None;
+                            return true;
+                        }
+                        tui.message_list = MessageListState::new();
+                    }
+                    Err(e) => {
+                        warn!("Failed to load session {}: {}", id, e);
+                        app.session.status_message = format!("Load failed: {}", e);
+                    }
+                }
+                tui.session_manager = None;
+            }
+            SessionEvent::CreateNew => {
+                let title = format!("Session #{}", session::next_session_number());
+                let effect = update(app, Action::NewSession { title });
+                if effect == Effect::Quit {
+                    tui.session_manager = None;
+                    return true;
+                }
+                tui.message_list = MessageListState::new();
+                tui.session_manager = None;
+            }
+            SessionEvent::Rename { id, new_title } => {
+                if let Err(e) = session::rename_session(&id, &new_title) {
+                    warn!("Failed to rename session {}: {}", id, e);
+                }
+                if update(app, Action::SessionRenamed { id, new_title }) == Effect::Quit {
+                    return true;
+                }
+            }
+            SessionEvent::Delete(id) => {
+                let is_active = app.session.current_session_id.as_deref() == Some(&id);
+                if let Err(e) = session::delete_session(&id) {
+                    warn!("Failed to delete session {}: {}", id, e);
+                }
+                sm.remove_session(&id);
+                let effect = update(app, Action::SessionDeleted(id));
+                if is_active {
+                    tui.message_list = MessageListState::new();
+                }
+                if effect == Effect::Quit {
+                    return true;
+                }
+            }
+            SessionEvent::Dismiss => {
+                tui.session_manager = None;
+            }
+        }
+    }
+    false
+}
+
+fn handle_model_picker_event(
+    event: &TuiEvent,
+    app: &mut App,
+    tui: &mut TuiState,
+    config: &ResolvedConfig,
+) -> bool {
+    let mp = tui.model_picker.as_mut().unwrap();
+    if let Some(picker_event) = mp.handle_event(event) {
+        match picker_event {
+            ModelPickerEvent::Select(entry) => {
+                let effect = update(
+                    app,
+                    Action::SwitchModel {
+                        name: entry.name.clone(),
+                        provider: entry.provider.clone(),
+                    },
+                );
+                if effect == Effect::RebuildProvider {
+                    let mut new_config = config.clone();
+                    new_config.provider = entry.provider.clone();
+                    new_config.model_name = entry.name.clone();
+                    app.provider = crate::inference::build_provider(&new_config);
+                }
+                info!("Model switched: {} ({})", entry.name, entry.provider);
+                tui.model_picker = None;
+            }
+            ModelPickerEvent::Dismiss => {
+                tui.model_picker = None;
+            }
+        }
+    }
+    false
+}

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -69,7 +69,10 @@ pub fn handle_event(
 
     if matches!(
         event,
-        TuiEvent::ScrollUp | TuiEvent::ScrollDown | TuiEvent::ScrollPageUp | TuiEvent::ScrollPageDown
+        TuiEvent::ScrollUp
+            | TuiEvent::ScrollDown
+            | TuiEvent::ScrollPageUp
+            | TuiEvent::ScrollPageDown
     ) {
         tui.message_list.handle_event(&event);
         return false;
@@ -282,8 +285,10 @@ fn handle_mouse_click(row: u16, app: &App, tui: &mut TuiState, frame_area: Rect)
     );
     if let Some(idx) = hit {
         tui.message_list.selected_index = Some(idx);
-        if matches!(app.session.context.items.get(idx), Some(ContextItem::ToolCall(_)))
-            && !tui.message_list.expanded_indices.remove(&idx)
+        if matches!(
+            app.session.context.items.get(idx),
+            Some(ContextItem::ToolCall(_))
+        ) && !tui.message_list.expanded_indices.remove(&idx)
         {
             tui.message_list.expanded_indices.insert(idx);
         }
@@ -383,4 +388,539 @@ fn handle_model_picker_event(
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::{
+        DEFAULT_LMSTUDIO_BASE_URL, DEFAULT_MAX_AGENTIC_ROUNDS, DEFAULT_MAX_OUTPUT_TOKENS,
+        DEFAULT_OPENROUTER_BASE_URL, DEFAULT_SYSTEM_PROMPT, ModelEntry,
+    };
+    use crate::inference::{ContextItem, ContextSegment, Effort, Source, ToolResult};
+    use crate::test_support::test_app;
+
+    fn test_tui_state() -> TuiState {
+        TuiState::new(Effort::default())
+    }
+
+    fn test_config() -> ResolvedConfig {
+        ResolvedConfig {
+            provider: "openrouter".to_string(),
+            model_name: "test-model".to_string(),
+            max_agentic_rounds: DEFAULT_MAX_AGENTIC_ROUNDS,
+            max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+            effort: Effort::default(),
+            system_prompt: DEFAULT_SYSTEM_PROMPT.to_string(),
+            openrouter_api_key: None,
+            openrouter_base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+            lmstudio_base_url: DEFAULT_LMSTUDIO_BASE_URL.to_string(),
+            models: Vec::new(),
+        }
+    }
+
+    fn test_frame_area() -> Rect {
+        Rect::new(0, 0, 80, 24)
+    }
+
+    // --- Phase 2: Top-level dispatch ---
+
+    #[test]
+    fn test_resize_is_noop() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        let quit = handle_event(
+            TuiEvent::Resize,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert!(!quit);
+    }
+
+    #[test]
+    fn test_force_quit_returns_true() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        let quit = handle_event(
+            TuiEvent::ForceQuit,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert!(quit);
+    }
+
+    #[test]
+    fn test_open_model_picker() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.fetched_models = Some(vec![ModelEntry {
+            name: "fetched-model".to_string(),
+            provider: "openrouter".to_string(),
+            description: None,
+        }]);
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        let quit = handle_event(
+            TuiEvent::OpenModelPicker,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert!(!quit);
+        assert!(tui.model_picker.is_some());
+    }
+
+    #[test]
+    fn test_model_picker_dismiss() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.model_picker = Some(ModelPickerState::new(vec![]));
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        let quit = handle_event(
+            TuiEvent::Escape,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert!(!quit);
+        assert!(tui.model_picker.is_none());
+    }
+
+    #[test]
+    fn test_scroll_events_dont_quit() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        for event in [
+            TuiEvent::ScrollUp,
+            TuiEvent::ScrollDown,
+            TuiEvent::ScrollPageUp,
+            TuiEvent::ScrollPageDown,
+        ] {
+            let quit = handle_event(event, &mut app, &mut tui, &config, &tx, test_frame_area());
+            assert!(!quit);
+        }
+    }
+
+    // --- Phase 3: Mode switching and input routing ---
+
+    #[test]
+    fn test_escape_switches_to_cursor_mode() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        assert_eq!(tui.input_mode, InputMode::Input);
+        // Add a user message so there's something to select
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::User,
+                content: "hello".to_string(),
+            }));
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::Escape,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert_eq!(tui.input_mode, InputMode::Cursor);
+        assert!(tui.message_list.selected_index.is_some());
+    }
+
+    #[test]
+    fn test_escape_selects_last_non_tool_result() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        // items[0] = system directive (from test_app)
+        // items[1] = user message
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::User,
+                content: "hello".to_string(),
+            }));
+        // items[2] = tool result (should be skipped)
+        app.session
+            .context
+            .items
+            .push(ContextItem::ToolResult(ToolResult {
+                call_id: "call_1".to_string(),
+                output: "result".to_string(),
+            }));
+        // items[3] = model message (should be selected)
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::Model,
+                content: "response".to_string(),
+            }));
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::Escape,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert_eq!(tui.message_list.selected_index, Some(3));
+    }
+
+    #[test]
+    fn test_typing_in_cursor_mode_switches_to_input() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.input_mode = InputMode::Cursor;
+        tui.message_list.selected_index = Some(0);
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::InputChar('a'),
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert_eq!(tui.input_mode, InputMode::Input);
+        assert_eq!(tui.message_list.selected_index, None);
+    }
+
+    #[test]
+    fn test_enter_in_cursor_mode_switches_to_input() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.input_mode = InputMode::Cursor;
+        tui.message_list.selected_index = Some(0);
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::Submit,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert_eq!(tui.input_mode, InputMode::Input);
+        assert_eq!(tui.message_list.selected_index, None);
+    }
+
+    #[test]
+    fn test_escape_while_loading_cancels_generation() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        app.session.is_loading = true;
+        // Add a fake abort handle
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let handle = rt.spawn(async {
+            loop {
+                tokio::task::yield_now().await
+            }
+        });
+        tui.active_abort_handles.push(handle.abort_handle());
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        let quit = handle_event(
+            TuiEvent::Escape,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert!(!quit);
+        assert!(tui.active_abort_handles.is_empty());
+        assert!(!app.session.is_loading);
+    }
+
+    // --- Phase 4: Navigation ---
+
+    #[test]
+    fn test_navigate_up_from_bottom() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.input_mode = InputMode::Cursor;
+        // Add 3 user messages (indices 1, 2, 3 — 0 is system)
+        for i in 0..3 {
+            app.session
+                .context
+                .items
+                .push(ContextItem::Message(ContextSegment {
+                    source: Source::User,
+                    content: format!("msg {i}"),
+                }));
+        }
+        tui.message_list.selected_index = Some(3); // last item
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::CursorUp,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert_eq!(tui.message_list.selected_index, Some(2));
+    }
+
+    #[test]
+    fn test_navigate_up_skips_tool_results() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.input_mode = InputMode::Cursor;
+        // [0]=system, [1]=user, [2]=tool_result, [3]=model
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::User,
+                content: "hello".to_string(),
+            }));
+        app.session
+            .context
+            .items
+            .push(ContextItem::ToolResult(ToolResult {
+                call_id: "c1".to_string(),
+                output: "out".to_string(),
+            }));
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::Model,
+                content: "response".to_string(),
+            }));
+        tui.message_list.selected_index = Some(3);
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::CursorUp,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        // Should skip index 2 (ToolResult) and land on 1
+        assert_eq!(tui.message_list.selected_index, Some(1));
+    }
+
+    #[test]
+    fn test_navigate_down_skips_tool_results() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.input_mode = InputMode::Cursor;
+        // [0]=system, [1]=user, [2]=tool_result, [3]=model
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::User,
+                content: "hello".to_string(),
+            }));
+        app.session
+            .context
+            .items
+            .push(ContextItem::ToolResult(ToolResult {
+                call_id: "c1".to_string(),
+                output: "out".to_string(),
+            }));
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::Model,
+                content: "response".to_string(),
+            }));
+        tui.message_list.selected_index = Some(1);
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::CursorDown,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        // Should skip index 2 (ToolResult) and land on 3
+        assert_eq!(tui.message_list.selected_index, Some(3));
+    }
+
+    #[test]
+    fn test_navigate_up_from_none_selects_last() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.input_mode = InputMode::Cursor;
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::User,
+                content: "hello".to_string(),
+            }));
+        tui.message_list.selected_index = None;
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::CursorUp,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        // Should select last item (index 1)
+        assert_eq!(tui.message_list.selected_index, Some(1));
+    }
+
+    #[test]
+    fn test_navigate_down_at_end_stays_put() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        tui.input_mode = InputMode::Cursor;
+        app.session
+            .context
+            .items
+            .push(ContextItem::Message(ContextSegment {
+                source: Source::User,
+                content: "hello".to_string(),
+            }));
+        tui.message_list.selected_index = Some(1); // last item
+        let config = test_config();
+        let (tx, _rx) = mpsc::channel();
+
+        handle_event(
+            TuiEvent::CursorDown,
+            &mut app,
+            &mut tui,
+            &config,
+            &tx,
+            test_frame_area(),
+        );
+
+        assert_eq!(tui.message_list.selected_index, Some(1));
+    }
+
+    // --- Phase 5: Background action processing ---
+
+    #[test]
+    fn test_background_actions_empty_channel() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        let (tx, rx) = mpsc::channel();
+
+        let (quit, had_actions) = process_background_actions(&rx, &mut app, &mut tui, &tx);
+
+        assert!(!quit);
+        assert!(!had_actions);
+    }
+
+    #[test]
+    fn test_background_actions_models_fetched() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        let (tx, rx) = mpsc::channel();
+        let models = vec![ModelEntry {
+            name: "test-model".to_string(),
+            provider: "openrouter".to_string(),
+            description: None,
+        }];
+        tx.send(Action::ModelsFetched(models.clone())).unwrap();
+
+        let (quit, had_actions) = process_background_actions(&rx, &mut app, &mut tui, &tx);
+
+        assert!(!quit);
+        assert!(had_actions);
+        assert_eq!(tui.fetched_models.as_ref().unwrap().len(), 1);
+        // ModelsFetched shouldn't reach the reducer — context items unchanged
+        assert_eq!(app.session.context.items.len(), 1); // just system
+    }
+
+    #[test]
+    fn test_background_actions_quit() {
+        let mut app = test_app();
+        let mut tui = test_tui_state();
+        let (tx, rx) = mpsc::channel();
+        tx.send(Action::Quit).unwrap();
+
+        let (quit, had_actions) = process_background_actions(&rx, &mut app, &mut tui, &tx);
+
+        assert!(quit);
+        assert!(had_actions);
+    }
+
+    #[test]
+    fn test_background_actions_response_chunk() {
+        let mut app = test_app();
+        app.session.is_loading = true;
+        let mut tui = test_tui_state();
+        let (tx, rx) = mpsc::channel();
+        tx.send(Action::ResponseChunk {
+            text: "hello".to_string(),
+            item_id: None,
+        })
+        .unwrap();
+
+        let (quit, had_actions) = process_background_actions(&rx, &mut app, &mut tui, &tx);
+
+        assert!(!quit);
+        assert!(had_actions);
+        // The chunk should have been processed by the reducer
+        assert_eq!(app.session.context.items.len(), 2); // system + model response
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -427,8 +427,10 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                                 }
                             }
                             InputEvent::CycleEffort => {
-                                app.effort = app.effort.next();
-                                app.status_message = format!("Reasoning: {}", app.effort.label());
+                                let effect = update(&mut app, Action::CycleEffort);
+                                if effect == Effect::Quit {
+                                    should_quit = true;
+                                }
                             }
                             InputEvent::ContentChanged => {}
                         }
@@ -509,8 +511,10 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                         }
                         // CycleEffort works in both modes
                         TuiEvent::CycleEffort => {
-                            app.effort = app.effort.next();
-                            app.status_message = format!("Reasoning: {}", app.effort.label());
+                            let effect = update(&mut app, Action::CycleEffort);
+                            if effect == Effect::Quit {
+                                should_quit = true;
+                            }
                         }
                         _ => {}
                     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -23,6 +23,7 @@ mod component;
 mod components;
 mod event;
 pub mod markdown;
+mod tasks;
 mod ui;
 
 use log::{debug, info, warn};
@@ -41,10 +42,8 @@ use crate::core::config::{ModelEntry, ResolvedConfig};
 use crate::core::session;
 use crate::core::state::App;
 use crate::inference::Effort;
-use crate::inference::model_discovery;
 use crate::inference::{
-    CompletionProvider, CompletionRequest, ContextItem, LmStudioProvider, OpenRouterProvider,
-    StreamChunk,
+    CompletionProvider, ContextItem, LmStudioProvider, OpenRouterProvider,
 };
 use crate::tui::component::EventHandler;
 use crate::tui::components::model_picker::ModelPickerEvent;
@@ -174,7 +173,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
     let (tx, rx) = mpsc::channel();
 
     // Fetch available models from providers in the background at startup
-    spawn_model_fetch(&app, tx.clone());
+    tasks::spawn_model_fetch(&app, tx.clone());
 
     // Abort handles for the current generation (used by Escape-to-cancel)
     let mut active_abort_handles: Vec<tokio::task::AbortHandle> = Vec::new();
@@ -435,7 +434,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                                 if !app.session.is_loading {
                                     let effect = update(&mut app, Action::Submit(text));
                                     if effect == Effect::SpawnRequest {
-                                        active_abort_handles = spawn_request(&app, tx.clone());
+                                        active_abort_handles = tasks::spawn_request(&app, tx.clone());
                                     }
                                 }
                             }
@@ -559,10 +558,10 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
             match effect {
                 Effect::Quit => break,
                 Effect::SpawnRequest => {
-                    active_abort_handles = spawn_request(&app, tx.clone());
+                    active_abort_handles = tasks::spawn_request(&app, tx.clone());
                 }
                 Effect::ExecuteTool(tool_call) => {
-                    spawn_tool_execution(tool_call, app.registry.clone(), tx.clone());
+                    tasks::spawn_tool_execution(tool_call, app.registry.clone(), tx.clone());
                 }
                 Effect::SaveSession => {
                     session::save_current_session(&mut app);
@@ -582,226 +581,4 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
     // mouse capture, drains buffered events, then calls ratatui::restore().
     // This ordering prevents escape sequence garbage on exit.
     Ok(())
-}
-
-fn spawn_tool_execution(
-    tool_call: crate::inference::ToolCall,
-    registry: Arc<crate::core::tools::ToolRegistry>,
-    tx: mpsc::Sender<Action>,
-) {
-    info!(
-        "Spawning tool execution: {} (call_id={})",
-        tool_call.name, tool_call.call_id
-    );
-    tokio::spawn(async move {
-        let output = match tokio::time::timeout(
-            std::time::Duration::from_secs(30),
-            registry.execute(&tool_call),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                warn!(
-                    "Tool '{}' timed out after 30s (call_id={})",
-                    tool_call.name, tool_call.call_id
-                );
-                serde_json::json!({"error": "Tool execution timed out after 30s"}).to_string()
-            }
-        };
-        if tx
-            .send(Action::ToolResultReady {
-                call_id: tool_call.call_id.clone(),
-                output,
-            })
-            .is_err()
-        {
-            warn!(
-                "Failed to send tool result for call_id={}: receiver dropped",
-                tool_call.call_id
-            );
-        }
-    });
-}
-
-fn spawn_request(app: &App, tx: mpsc::Sender<Action>) -> Vec<tokio::task::AbortHandle> {
-    info!("Spawning API request");
-
-    // Clone what we need for the async task
-    let provider = app.provider.clone();
-    let context = app.session.context.clone();
-    let model = app.model_name.clone();
-    let effort = app.effort;
-    let tools = app.tool_definitions();
-    let max_output_tokens = Some(app.max_output_tokens);
-
-    // Async channel for streaming chunks
-    let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::channel::<StreamChunk>(100);
-
-    // Clone tx for the streaming task
-    let tx_stream = tx.clone();
-
-    // Spawn the provider streaming task
-    let stream_handle = tokio::spawn(async move {
-        let request = CompletionRequest {
-            context: &context,
-            model: &model,
-            effort,
-            tools: &tools,
-            max_output_tokens,
-        };
-
-        if let Err(e) = provider.stream_completion(request, chunk_tx).await {
-            info!("Stream error: {}", e);
-            if tx_stream
-                .send(Action::ResponseChunk {
-                    text: format!("\n[Error: {}]", e),
-                    item_id: None,
-                })
-                .is_err()
-            {
-                warn!("Failed to send stream error action: receiver dropped");
-            }
-        }
-    });
-
-    // Spawn a task to forward chunks to the Action channel
-    let forward_handle = tokio::spawn(async move {
-        let mut forwarded_count = 0usize;
-        let mut total_content_len = 0usize;
-
-        // Client-side timing
-        let request_start = std::time::Instant::now();
-        let mut first_content_time: Option<std::time::Instant> = None;
-
-        while let Some(chunk) = chunk_rx.recv().await {
-            forwarded_count += 1;
-            match chunk {
-                StreamChunk::Content { text, item_id } => {
-                    if first_content_time.is_none() {
-                        first_content_time = Some(std::time::Instant::now());
-                    }
-                    total_content_len += text.len();
-                    debug!(
-                        "Forwarding Action::ResponseChunk (len={}, total={})",
-                        text.len(),
-                        total_content_len
-                    );
-                    if tx.send(Action::ResponseChunk { text, item_id }).is_err() {
-                        warn!("Failed to forward ResponseChunk: receiver dropped");
-                        return;
-                    }
-                }
-                StreamChunk::Thinking { text, item_id } => {
-                    if first_content_time.is_none() {
-                        first_content_time = Some(std::time::Instant::now());
-                    }
-                    debug!("Forwarding Action::ThinkingChunk (len={})", text.len());
-                    if tx.send(Action::ThinkingChunk { text, item_id }).is_err() {
-                        warn!("Failed to forward ThinkingChunk: receiver dropped");
-                        return;
-                    }
-                }
-                StreamChunk::ToolCall(tc) => {
-                    debug!("Forwarding ToolCall: {} (call_id={})", tc.name, tc.call_id);
-                    if tx.send(Action::ToolCallReceived(tc)).is_err() {
-                        warn!("Failed to forward ToolCall: receiver dropped");
-                        return;
-                    }
-                }
-                StreamChunk::Completed(provider_stats) => {
-                    let duration_ms = request_start.elapsed().as_millis() as u64;
-                    let ttft_ms =
-                        first_content_time.map(|t| (t - request_start).as_millis() as u64);
-
-                    // Enrich provider stats with client-side timing
-                    let mut stats = provider_stats.unwrap_or_default();
-                    stats.ttft_ms = ttft_ms;
-                    stats.generation_duration_ms = Some(duration_ms);
-                    if let Some(output_tokens) = stats.output_tokens
-                        && duration_ms > 0
-                    {
-                        stats.tokens_per_sec =
-                            Some(output_tokens as f32 / (duration_ms as f32 / 1000.0));
-                    }
-
-                    debug!(
-                        "Stream completed: ttft={}ms, duration={}ms, tok/s={:?}",
-                        ttft_ms.unwrap_or(0),
-                        duration_ms,
-                        stats.tokens_per_sec
-                    );
-
-                    info!(
-                        "Forwarding complete: {} actions, {} content bytes",
-                        forwarded_count, total_content_len
-                    );
-                    if tx.send(Action::ResponseDone(Some(stats))).is_err() {
-                        warn!("Failed to send ResponseDone: receiver dropped");
-                    }
-                    return;
-                }
-            }
-        }
-
-        // Fallback: channel closed without a Completed event
-        info!(
-            "Stream channel closed: {} actions, {} content bytes",
-            forwarded_count, total_content_len
-        );
-        if tx.send(Action::ResponseDone(None)).is_err() {
-            warn!("Failed to send ResponseDone: receiver dropped");
-        }
-    });
-
-    vec![stream_handle.abort_handle(), forward_handle.abort_handle()]
-}
-
-/// Spawns a background task to fetch models from all configured providers.
-///
-/// Runs OpenRouter and LM Studio fetches concurrently via `tokio::join!`.
-/// LM Studio has a 3s timeout so it won't block if the server isn't running.
-/// Results are deduped against pinned models in `ModelPickerState::set_fetched_models()`.
-fn spawn_model_fetch(app: &App, tx: mpsc::Sender<Action>) {
-    let openrouter_base_url = app.openrouter_base_url.clone();
-    let openrouter_api_key = app.openrouter_api_key.clone();
-    let lmstudio_base_url = app.lmstudio_base_url.clone();
-
-    tokio::spawn(async move {
-        let (or_result, lms_result) = tokio::join!(
-            async {
-                match openrouter_api_key {
-                    Some(ref key) => {
-                        model_discovery::fetch_openrouter_models(&openrouter_base_url, key).await
-                    }
-                    None => {
-                        warn!("No OpenRouter API key — skipping model fetch");
-                        Ok(Vec::new())
-                    }
-                }
-            },
-            async { model_discovery::fetch_lmstudio_models(&lmstudio_base_url).await }
-        );
-
-        let mut all_models = Vec::new();
-
-        match or_result {
-            Ok(models) => all_models.extend(models),
-            Err(e) => warn!("OpenRouter model fetch failed: {}", e),
-        }
-
-        match lms_result {
-            Ok(models) => all_models.extend(models),
-            Err(e) => debug!(
-                "LM Studio model fetch failed (server may not be running): {}",
-                e
-            ),
-        }
-
-        info!("Model fetch complete: {} total models", all_models.len());
-
-        if tx.send(Action::ModelsFetched(all_models)).is_err() {
-            warn!("Failed to send ModelsFetched: receiver dropped");
-        }
-    });
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -323,11 +323,15 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                             }
                         }
                         SessionEvent::Delete(id) => {
+                            let is_active = app.session.current_session_id.as_deref() == Some(&id);
                             if let Err(e) = session::delete_session(&id) {
                                 warn!("Failed to delete session {}: {}", id, e);
                             }
                             sm.remove_session(&id);
                             let effect = update(&mut app, Action::SessionDeleted(id));
+                            if is_active {
+                                tui.message_list = MessageListState::new();
+                            }
                             if effect == Effect::Quit {
                                 should_quit = true;
                             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -180,10 +180,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
         tui.input_box.dimmed = matches!(tui.input_mode, InputMode::Cursor);
 
         // Determine if animations are running (landing page or loading spinner)
-        let has_visible_messages = app.context.items.iter().any(|item|
-            matches!(item, crate::inference::ContextItem::Message(seg) if matches!(seg.source, crate::inference::Source::User | crate::inference::Source::Model))
-        );
-        let animating = app.is_loading || !has_visible_messages;
+        let animating = app.is_loading || !app.context.has_visible_messages();
 
         if animating {
             needs_redraw = true;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -189,7 +189,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
         tui.input_box.dimmed = matches!(tui.input_mode, InputMode::Cursor);
 
         // Determine if animations are running (landing page or loading spinner)
-        let animating = app.is_loading || !app.context.has_visible_messages();
+        let animating = app.session.is_loading || !app.session.context.has_visible_messages();
 
         if animating {
             needs_redraw = true;
@@ -296,7 +296,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                                 }
                                 Err(e) => {
                                     warn!("Failed to load session {}: {}", id, e);
-                                    app.status_message = format!("Load failed: {}", e);
+                                    app.session.status_message = format!("Load failed: {}", e);
                                 }
                             }
                             tui.session_manager = None;
@@ -372,7 +372,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
 
                 if let Some(idx) = hit {
                     tui.message_list.selected_index = Some(idx);
-                    if matches!(app.context.items.get(idx), Some(ContextItem::ToolCall(_)))
+                    if matches!(app.session.context.items.get(idx), Some(ContextItem::ToolCall(_)))
                         && !tui.message_list.expanded_indices.remove(&idx)
                     {
                         tui.message_list.expanded_indices.insert(idx);
@@ -397,7 +397,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
             match tui.input_mode {
                 InputMode::Input => {
                     // Esc while loading → cancel generation
-                    if matches!(event, TuiEvent::Escape) && app.is_loading {
+                    if matches!(event, TuiEvent::Escape) && app.session.is_loading {
                         for handle in active_abort_handles.drain(..) {
                             handle.abort();
                         }
@@ -411,7 +411,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                     if matches!(event, TuiEvent::Escape) {
                         tui.input_mode = InputMode::Cursor;
                         // Select the last non-ToolResult item when entering Cursor mode
-                        let items = &app.context.items;
+                        let items = &app.session.context.items;
                         let mut idx = items.len();
                         while idx > 0 {
                             idx -= 1;
@@ -428,7 +428,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                     if let Some(input_event) = tui.input_box.handle_event(&event) {
                         match input_event {
                             InputEvent::Submit(text) => {
-                                if !app.is_loading {
+                                if !app.session.is_loading {
                                     let effect = update(&mut app, Action::Submit(text));
                                     if effect == Effect::SpawnRequest {
                                         active_abort_handles = spawn_request(&app, tx.clone());
@@ -448,7 +448,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                 InputMode::Cursor => {
                     match event {
                         // Esc while loading → cancel generation
-                        TuiEvent::Escape if app.is_loading => {
+                        TuiEvent::Escape if app.session.is_loading => {
                             for handle in active_abort_handles.drain(..) {
                                 handle.abort();
                             }
@@ -463,7 +463,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                         TuiEvent::InputChar(' ') => {
                             if let Some(idx) = tui.message_list.selected_index
                                 && matches!(
-                                    app.context.items.get(idx),
+                                    app.session.context.items.get(idx),
                                     Some(ContextItem::ToolCall(_))
                                 )
                                 && !tui.message_list.expanded_indices.remove(&idx)
@@ -484,7 +484,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                         }
                         // Up/Down navigate messages (skipping consumed ToolResults)
                         TuiEvent::CursorUp => {
-                            let items = &app.context.items;
+                            let items = &app.session.context.items;
                             if !items.is_empty() {
                                 let mut idx = tui
                                     .message_list
@@ -500,7 +500,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                             }
                         }
                         TuiEvent::CursorDown => {
-                            let items = &app.context.items;
+                            let items = &app.session.context.items;
                             if let Some(mut idx) = tui.message_list.selected_index
                                 && idx + 1 < items.len()
                             {
@@ -625,7 +625,7 @@ fn spawn_request(app: &App, tx: mpsc::Sender<Action>) -> Vec<tokio::task::AbortH
 
     // Clone what we need for the async task
     let provider = app.provider.clone();
-    let context = app.context.clone();
+    let context = app.session.context.clone();
     let model = app.model_name.clone();
     let effort = app.effort;
     let tools = app.tool_definitions();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -128,6 +128,15 @@ impl Drop for TerminalModeGuard {
             DisableBracketedPaste,
             Hide // Hide cursor on exit
         );
+
+        // Drain any buffered mouse/keyboard events before restoring the terminal.
+        // If ratatui::restore() disables raw mode while mouse tracking escape
+        // sequences are still buffered, they leak as visible garbage (e.g. "35;37;36M").
+        while crossterm::event::poll(std::time::Duration::ZERO).unwrap_or(false) {
+            let _ = crossterm::event::read();
+        }
+
+        ratatui::restore();
     }
 }
 
@@ -565,7 +574,9 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
     // Save on exit if there's content
     session::save_current_session(&mut app);
 
-    ratatui::restore();
+    // Terminal restoration happens in TerminalModeGuard::drop() — it disables
+    // mouse capture, drains buffered events, then calls ratatui::restore().
+    // This ordering prevents escape sequence garbage on exit.
     Ok(())
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -22,11 +22,12 @@
 mod component;
 mod components;
 mod event;
+mod handlers;
 pub mod markdown;
 mod tasks;
 mod ui;
 
-use log::{debug, info, warn};
+use log::info;
 use std::io::stdout;
 use std::sync::mpsc;
 
@@ -37,18 +38,12 @@ use crossterm::event::{
 };
 use crossterm::execute;
 
-use crate::core::action::{Action, Effect, update};
 use crate::core::config::{ModelEntry, ResolvedConfig};
 use crate::core::session;
 use crate::core::state::App;
-use crate::inference::{ContextItem, Effort};
-use crate::tui::component::EventHandler;
-use crate::tui::components::model_picker::ModelPickerEvent;
-use crate::tui::components::session_manager::SessionEvent;
-use crate::tui::components::{
-    InputBox, InputEvent, MessageListState, ModelPickerState, SessionManagerState,
-};
-use crate::tui::event::{TuiEvent, poll_event_immediate, poll_event_timeout};
+use crate::inference::Effort;
+use crate::tui::components::{InputBox, MessageListState, ModelPickerState, SessionManagerState};
+use crate::tui::event::{poll_event_immediate, poll_event_timeout};
 
 /// Modal input mode: determines how keyboard events are interpreted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,6 +69,8 @@ pub struct TuiState {
     pub model_picker: Option<ModelPickerState>,
     // Pre-fetched models from provider APIs (populated at startup)
     pub fetched_models: Option<Vec<ModelEntry>>,
+    // Abort handles for the current generation (used by Escape-to-cancel)
+    pub active_abort_handles: Vec<tokio::task::AbortHandle>,
 }
 
 impl TuiState {
@@ -86,6 +83,7 @@ impl TuiState {
             session_manager: None,
             model_picker: None,
             fetched_models: None,
+            active_abort_handles: Vec::new(),
         }
     }
 }
@@ -154,9 +152,6 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
     // Fetch available models from providers in the background at startup
     tasks::spawn_model_fetch(&app, tx.clone());
 
-    // Abort handles for the current generation (used by Escape-to-cancel)
-    let mut active_abort_handles: Vec<tokio::task::AbortHandle> = Vec::new();
-
     // Animation timer
     let start_time = std::time::Instant::now();
     let mut needs_redraw = true; // Force first frame
@@ -195,321 +190,13 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
         if first_event.is_some() {
             needs_redraw = true;
         }
+        let frame_area = terminal.get_frame().area();
         for event in first_event
             .into_iter()
             .chain(std::iter::from_fn(poll_event_immediate))
         {
-            // Resize just needs a redraw (already flagged above)
-            if matches!(event, TuiEvent::Resize) {
-                continue;
-            }
-
-            // ForceQuit (Ctrl+C) always quits regardless of mode
-            if matches!(event, TuiEvent::ForceQuit) {
-                let effect = update(&mut app, Action::Quit);
-                if effect == Effect::Quit {
-                    should_quit = true;
-                }
-                continue;
-            }
-
-            // Ctrl+O opens session manager
-            if matches!(event, TuiEvent::OpenSessionManager) {
-                let index = session::load_index().unwrap_or_default();
-                tui.session_manager = Some(SessionManagerState::new(index.sessions));
-                continue;
-            }
-
-            // Ctrl+P opens model picker (models pre-fetched at startup)
-            if matches!(event, TuiEvent::OpenModelPicker) {
-                let mut picker = ModelPickerState::new(app.available_models.clone());
-                if let Some(ref models) = tui.fetched_models {
-                    picker.set_fetched_models(models.clone());
-                }
-                tui.model_picker = Some(picker);
-                continue;
-            }
-
-            // When model picker is open, route all events to it
-            if let Some(ref mut mp) = tui.model_picker {
-                if let Some(picker_event) = mp.handle_event(&event) {
-                    match picker_event {
-                        ModelPickerEvent::Select(entry) => {
-                            let effect = update(
-                                &mut app,
-                                Action::SwitchModel {
-                                    name: entry.name.clone(),
-                                    provider: entry.provider.clone(),
-                                },
-                            );
-                            if effect == Effect::RebuildProvider {
-                                let mut new_config = config.clone();
-                                new_config.provider = entry.provider.clone();
-                                new_config.model_name = entry.name.clone();
-                                app.provider = crate::inference::build_provider(&new_config);
-                            }
-                            info!("Model switched: {} ({})", entry.name, entry.provider);
-                            tui.model_picker = None;
-                        }
-                        ModelPickerEvent::Dismiss => {
-                            tui.model_picker = None;
-                        }
-                    }
-                }
-                continue;
-            }
-
-            // When session manager is open, route all events to it
-            if let Some(ref mut sm) = tui.session_manager {
-                if let Some(session_event) = sm.handle_event(&event) {
-                    match session_event {
-                        SessionEvent::Load(id) => {
-                            match session::load_session(&id) {
-                                Ok(data) => {
-                                    let effect = update(&mut app, Action::LoadSession(data));
-                                    if effect == Effect::Quit {
-                                        should_quit = true;
-                                    }
-                                    tui.message_list = MessageListState::new();
-                                }
-                                Err(e) => {
-                                    warn!("Failed to load session {}: {}", id, e);
-                                    app.session.status_message = format!("Load failed: {}", e);
-                                }
-                            }
-                            tui.session_manager = None;
-                        }
-                        SessionEvent::CreateNew => {
-                            let title =
-                                format!("Session #{}", session::next_session_number());
-                            let effect =
-                                update(&mut app, Action::NewSession { title });
-                            if effect == Effect::Quit {
-                                should_quit = true;
-                            }
-                            tui.message_list = MessageListState::new();
-                            tui.session_manager = None;
-                        }
-                        SessionEvent::Rename { id, new_title } => {
-                            if let Err(e) = session::rename_session(&id, &new_title) {
-                                warn!("Failed to rename session {}: {}", id, e);
-                            }
-                            let effect =
-                                update(&mut app, Action::SessionRenamed { id, new_title });
-                            if effect == Effect::Quit {
-                                should_quit = true;
-                            }
-                        }
-                        SessionEvent::Delete(id) => {
-                            let is_active = app.session.current_session_id.as_deref() == Some(&id);
-                            if let Err(e) = session::delete_session(&id) {
-                                warn!("Failed to delete session {}: {}", id, e);
-                            }
-                            sm.remove_session(&id);
-                            let effect = update(&mut app, Action::SessionDeleted(id));
-                            if is_active {
-                                tui.message_list = MessageListState::new();
-                            }
-                            if effect == Effect::Quit {
-                                should_quit = true;
-                            }
-                        }
-                        SessionEvent::Dismiss => {
-                            tui.session_manager = None;
-                        }
-                    }
-                }
-                continue;
-            }
-
-            // Mouse hover — always active regardless of mode
-            if let TuiEvent::MouseMove(_col, row) = event {
-                let frame_area = terminal.get_frame().area();
-                let scroll_offset = tui.message_list.scroll_state.offset().y;
-                let input_height = tui.input_box.calculate_height(frame_area.width);
-
-                tui.message_list.selected_index = ui::hit_test_message(
-                    row,
-                    frame_area,
-                    scroll_offset,
-                    &tui.message_list.layout.prefix_heights,
-                    input_height,
-                );
-                continue;
-            }
-
-            // Mouse click — toggle expansion on tool calls
-            if let TuiEvent::MouseClick(_col, row) = event {
-                let frame_area = terminal.get_frame().area();
-                let scroll_offset = tui.message_list.scroll_state.offset().y;
-                let input_height = tui.input_box.calculate_height(frame_area.width);
-
-                let hit = ui::hit_test_message(
-                    row,
-                    frame_area,
-                    scroll_offset,
-                    &tui.message_list.layout.prefix_heights,
-                    input_height,
-                );
-
-                if let Some(idx) = hit {
-                    tui.message_list.selected_index = Some(idx);
-                    if matches!(app.session.context.items.get(idx), Some(ContextItem::ToolCall(_)))
-                        && !tui.message_list.expanded_indices.remove(&idx)
-                    {
-                        tui.message_list.expanded_indices.insert(idx);
-                    }
-                }
-                continue;
-            }
-
-            // Scroll events — always go to MessageList regardless of mode
-            if matches!(
-                event,
-                TuiEvent::ScrollUp
-                    | TuiEvent::ScrollDown
-                    | TuiEvent::ScrollPageUp
-                    | TuiEvent::ScrollPageDown
-            ) {
-                tui.message_list.handle_event(&event);
-                continue;
-            }
-
-            // Modal event dispatch
-            match tui.input_mode {
-                InputMode::Input => {
-                    // Esc while loading → cancel generation
-                    if matches!(event, TuiEvent::Escape) && app.session.is_loading {
-                        for handle in active_abort_handles.drain(..) {
-                            handle.abort();
-                        }
-                        let effect = update(&mut app, Action::CancelGeneration);
-                        if effect == Effect::Quit {
-                            should_quit = true;
-                        }
-                        continue;
-                    }
-                    // Esc → switch to Cursor mode
-                    if matches!(event, TuiEvent::Escape) {
-                        tui.input_mode = InputMode::Cursor;
-                        // Select the last non-ToolResult item when entering Cursor mode
-                        let items = &app.session.context.items;
-                        let mut idx = items.len();
-                        while idx > 0 {
-                            idx -= 1;
-                            if !matches!(items[idx], ContextItem::ToolResult(_)) {
-                                break;
-                            }
-                        }
-                        tui.message_list.selected_index =
-                            if !items.is_empty() { Some(idx) } else { None };
-                        continue;
-                    }
-
-                    // InputBox handles everything else
-                    if let Some(input_event) = tui.input_box.handle_event(&event) {
-                        match input_event {
-                            InputEvent::Submit(text) => {
-                                if !app.session.is_loading {
-                                    let effect = update(&mut app, Action::Submit(text));
-                                    if effect == Effect::SpawnRequest {
-                                        active_abort_handles = tasks::spawn_request(&app, tx.clone());
-                                    }
-                                }
-                            }
-                            InputEvent::CycleEffort => {
-                                let effect = update(&mut app, Action::CycleEffort);
-                                if effect == Effect::Quit {
-                                    should_quit = true;
-                                }
-                            }
-                            InputEvent::ContentChanged => {}
-                        }
-                    }
-                }
-                InputMode::Cursor => {
-                    match event {
-                        // Esc while loading → cancel generation
-                        TuiEvent::Escape if app.session.is_loading => {
-                            for handle in active_abort_handles.drain(..) {
-                                handle.abort();
-                            }
-                            let effect = update(&mut app, Action::CancelGeneration);
-                            if effect == Effect::Quit {
-                                should_quit = true;
-                            }
-                        }
-                        // Esc in Cursor mode is a no-op
-                        TuiEvent::Escape => {}
-                        // Space toggles expansion of selected tool call
-                        TuiEvent::InputChar(' ') => {
-                            if let Some(idx) = tui.message_list.selected_index
-                                && matches!(
-                                    app.session.context.items.get(idx),
-                                    Some(ContextItem::ToolCall(_))
-                                )
-                                && !tui.message_list.expanded_indices.remove(&idx)
-                            {
-                                tui.message_list.expanded_indices.insert(idx);
-                            }
-                        }
-                        // Typing auto-switches to Input mode and forwards the event
-                        TuiEvent::InputChar(_) | TuiEvent::Paste(_) => {
-                            tui.input_mode = InputMode::Input;
-                            tui.message_list.selected_index = None;
-                            tui.input_box.handle_event(&event);
-                        }
-                        // Enter switches to Input mode
-                        TuiEvent::Submit => {
-                            tui.input_mode = InputMode::Input;
-                            tui.message_list.selected_index = None;
-                        }
-                        // Up/Down navigate messages (skipping consumed ToolResults)
-                        TuiEvent::CursorUp => {
-                            let items = &app.session.context.items;
-                            if !items.is_empty() {
-                                let mut idx = tui
-                                    .message_list
-                                    .selected_index
-                                    .map(|i| i.saturating_sub(1))
-                                    .unwrap_or(items.len() - 1);
-                                // Skip backwards past ToolResult items
-                                while idx > 0 && matches!(items[idx], ContextItem::ToolResult(_)) {
-                                    idx -= 1;
-                                }
-                                tui.message_list.selected_index = Some(idx);
-                                tui.message_list.scroll_to_selected();
-                            }
-                        }
-                        TuiEvent::CursorDown => {
-                            let items = &app.session.context.items;
-                            if let Some(mut idx) = tui.message_list.selected_index
-                                && idx + 1 < items.len()
-                            {
-                                idx += 1;
-                                // Skip forwards past ToolResult items
-                                while idx < items.len()
-                                    && matches!(items[idx], ContextItem::ToolResult(_))
-                                {
-                                    idx += 1;
-                                }
-                                // Only update if we landed on a valid index
-                                if idx < items.len() {
-                                    tui.message_list.selected_index = Some(idx);
-                                    tui.message_list.scroll_to_selected();
-                                }
-                            }
-                        }
-                        // CycleEffort works in both modes
-                        TuiEvent::CycleEffort => {
-                            let effect = update(&mut app, Action::CycleEffort);
-                            if effect == Effect::Quit {
-                                should_quit = true;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+            if handlers::handle_event(event, &mut app, &mut tui, &config, &tx, frame_area) {
+                should_quit = true;
             }
         }
 
@@ -518,38 +205,12 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
         }
 
         // Handle background task actions (streaming responses)
-        while let Ok(action) = rx.try_recv() {
+        let (quit, had_actions) = handlers::process_background_actions(&rx, &mut app, &mut tui, &tx);
+        if had_actions {
             needs_redraw = true;
-
-            // Intercept ModelsFetched — this is TUI-only state, not core business logic.
-            // Cache results for future picker opens; also update picker if currently open.
-            if let Action::ModelsFetched(models) = action {
-                debug!("Received {} fetched models", models.len());
-                tui.fetched_models = Some(models.clone());
-                if let Some(ref mut mp) = tui.model_picker {
-                    mp.set_fetched_models(models);
-                }
-                continue;
-            }
-
-            debug!("Event loop received: {:?}", action);
-            let effect = update(&mut app, action);
-            match effect {
-                Effect::Quit => break,
-                Effect::SpawnRequest => {
-                    active_abort_handles = tasks::spawn_request(&app, tx.clone());
-                }
-                Effect::ExecuteTool(tool_call) => {
-                    tasks::spawn_tool_execution(tool_call, app.registry.clone(), tx.clone());
-                }
-                Effect::SaveSession => {
-                    session::save_current_session(&mut app);
-                }
-                Effect::RebuildProvider => {
-                    warn!("Unexpected RebuildProvider from background action");
-                }
-                _ => {}
-            }
+        }
+        if quit {
+            break;
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,7 +28,7 @@ mod ui;
 
 use log::{debug, info, warn};
 use std::io::stdout;
-use std::sync::{Arc, mpsc};
+use std::sync::mpsc;
 
 use crossterm::cursor::{Hide, SetCursorStyle, Show};
 use crossterm::event::{
@@ -41,10 +41,7 @@ use crate::core::action::{Action, Effect, update};
 use crate::core::config::{ModelEntry, ResolvedConfig};
 use crate::core::session;
 use crate::core::state::App;
-use crate::inference::Effort;
-use crate::inference::{
-    CompletionProvider, ContextItem, LmStudioProvider, OpenRouterProvider,
-};
+use crate::inference::{ContextItem, Effort};
 use crate::tui::component::EventHandler;
 use crate::tui::components::model_picker::ModelPickerEvent;
 use crate::tui::components::session_manager::SessionEvent;
@@ -139,26 +136,8 @@ impl Drop for TerminalModeGuard {
     }
 }
 
-/// Build a provider from a resolved config's provider name and credentials.
-pub fn build_provider(config: &ResolvedConfig) -> Arc<dyn CompletionProvider> {
-    match config.provider.as_str() {
-        "lmstudio" => Arc::new(LmStudioProvider::new(config.lmstudio_base_url.clone())),
-        _ => {
-            // Default to openrouter
-            let api_key = config
-                .openrouter_api_key
-                .clone()
-                .expect("OpenRouter API key must be set (config file, OPENROUTER_API_KEY env var, or --provider lmstudio)");
-            Arc::new(OpenRouterProvider::new(
-                api_key,
-                Some(config.openrouter_base_url.clone()),
-            ))
-        }
-    }
-}
-
 pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
-    let provider = build_provider(&config);
+    let provider = crate::inference::build_provider(&config);
     let mut app = App::from_config(provider, &config);
     let mut tui = TuiState::new(app.effort);
 
@@ -267,7 +246,7 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                                 let mut new_config = config.clone();
                                 new_config.provider = entry.provider.clone();
                                 new_config.model_name = entry.name.clone();
-                                app.provider = build_provider(&new_config);
+                                app.provider = crate::inference::build_provider(&new_config);
                             }
                             info!("Model switched: {} ({})", entry.name, entry.provider);
                             tui.model_picker = None;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -296,13 +296,13 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                             tui.session_manager = None;
                         }
                         SessionEvent::CreateNew => {
-                            let effect = update(&mut app, Action::NewSession);
+                            let title =
+                                format!("Session #{}", session::next_session_number());
+                            let effect =
+                                update(&mut app, Action::NewSession { title });
                             if effect == Effect::Quit {
                                 should_quit = true;
                             }
-                            // Assign "Session #N" title immediately
-                            app.session_title =
-                                format!("Session #{}", session::next_session_number());
                             tui.message_list = MessageListState::new();
                             tui.session_manager = None;
                         }
@@ -310,9 +310,10 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                             if let Err(e) = session::rename_session(&id, &new_title) {
                                 warn!("Failed to rename session {}: {}", id, e);
                             }
-                            // Update active session title if renaming the current one
-                            if app.current_session_id.as_deref() == Some(&id) {
-                                app.session_title = new_title;
+                            let effect =
+                                update(&mut app, Action::SessionRenamed { id, new_title });
+                            if effect == Effect::Quit {
+                                should_quit = true;
                             }
                         }
                         SessionEvent::Delete(id) => {
@@ -320,9 +321,9 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                                 warn!("Failed to delete session {}: {}", id, e);
                             }
                             sm.remove_session(&id);
-                            // If we deleted the active session, clear the ID
-                            if app.current_session_id.as_deref() == Some(&id) {
-                                app.current_session_id = None;
+                            let effect = update(&mut app, Action::SessionDeleted(id));
+                            if effect == Effect::Quit {
+                                should_quit = true;
                             }
                         }
                         SessionEvent::Dismiss => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -251,17 +251,19 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                 if let Some(picker_event) = mp.handle_event(&event) {
                     match picker_event {
                         ModelPickerEvent::Select(entry) => {
-                            // Build a new resolved config with the selected model/provider
-                            let mut new_config = config.clone();
-                            new_config.provider = entry.provider.clone();
-                            new_config.model_name = entry.name.clone();
-
-                            // Rebuild the provider for the new model
-                            app.provider = build_provider(&new_config);
-                            app.model_name = entry.name.clone();
-                            app.provider_name = entry.provider.clone();
-                            app.status_message =
-                                format!("Switched to {} ({})", entry.name, entry.provider);
+                            let effect = update(
+                                &mut app,
+                                Action::SwitchModel {
+                                    name: entry.name.clone(),
+                                    provider: entry.provider.clone(),
+                                },
+                            );
+                            if effect == Effect::RebuildProvider {
+                                let mut new_config = config.clone();
+                                new_config.provider = entry.provider.clone();
+                                new_config.model_name = entry.name.clone();
+                                app.provider = build_provider(&new_config);
+                            }
                             info!("Model switched: {} ({})", entry.name, entry.provider);
                             tui.model_picker = None;
                         }
@@ -553,6 +555,9 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
                 }
                 Effect::SaveSession => {
                     session::save_current_session(&mut app);
+                }
+                Effect::RebuildProvider => {
+                    warn!("Unexpected RebuildProvider from background action");
                 }
                 _ => {}
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -205,7 +205,8 @@ pub fn run(config: ResolvedConfig) -> std::io::Result<()> {
         }
 
         // Handle background task actions (streaming responses)
-        let (quit, had_actions) = handlers::process_background_actions(&rx, &mut app, &mut tui, &tx);
+        let (quit, had_actions) =
+            handlers::process_background_actions(&rx, &mut app, &mut tui, &tx);
         if had_actions {
             needs_redraw = true;
         }

--- a/src/tui/tasks.rs
+++ b/src/tui/tasks.rs
@@ -1,0 +1,230 @@
+//! Background task spawners for async operations (API requests, tool execution, model fetching).
+
+use log::{debug, info, warn};
+use std::sync::{Arc, mpsc};
+
+use crate::core::action::Action;
+use crate::core::state::App;
+use crate::inference::{CompletionRequest, StreamChunk, model_discovery};
+
+pub fn spawn_tool_execution(
+    tool_call: crate::inference::ToolCall,
+    registry: Arc<crate::core::tools::ToolRegistry>,
+    tx: mpsc::Sender<Action>,
+) {
+    info!(
+        "Spawning tool execution: {} (call_id={})",
+        tool_call.name, tool_call.call_id
+    );
+    tokio::spawn(async move {
+        let output = match tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            registry.execute(&tool_call),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                warn!(
+                    "Tool '{}' timed out after 30s (call_id={})",
+                    tool_call.name, tool_call.call_id
+                );
+                serde_json::json!({"error": "Tool execution timed out after 30s"}).to_string()
+            }
+        };
+        if tx
+            .send(Action::ToolResultReady {
+                call_id: tool_call.call_id.clone(),
+                output,
+            })
+            .is_err()
+        {
+            warn!(
+                "Failed to send tool result for call_id={}: receiver dropped",
+                tool_call.call_id
+            );
+        }
+    });
+}
+
+pub fn spawn_request(app: &App, tx: mpsc::Sender<Action>) -> Vec<tokio::task::AbortHandle> {
+    info!("Spawning API request");
+
+    // Clone what we need for the async task
+    let provider = app.provider.clone();
+    let context = app.session.context.clone();
+    let model = app.model_name.clone();
+    let effort = app.effort;
+    let tools = app.tool_definitions();
+    let max_output_tokens = Some(app.max_output_tokens);
+
+    // Async channel for streaming chunks
+    let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::channel::<StreamChunk>(100);
+
+    // Clone tx for the streaming task
+    let tx_stream = tx.clone();
+
+    // Spawn the provider streaming task
+    let stream_handle = tokio::spawn(async move {
+        let request = CompletionRequest {
+            context: &context,
+            model: &model,
+            effort,
+            tools: &tools,
+            max_output_tokens,
+        };
+
+        if let Err(e) = provider.stream_completion(request, chunk_tx).await {
+            info!("Stream error: {}", e);
+            if tx_stream
+                .send(Action::ResponseChunk {
+                    text: format!("\n[Error: {}]", e),
+                    item_id: None,
+                })
+                .is_err()
+            {
+                warn!("Failed to send stream error action: receiver dropped");
+            }
+        }
+    });
+
+    // Spawn a task to forward chunks to the Action channel
+    let forward_handle = tokio::spawn(async move {
+        let mut forwarded_count = 0usize;
+        let mut total_content_len = 0usize;
+
+        // Client-side timing
+        let request_start = std::time::Instant::now();
+        let mut first_content_time: Option<std::time::Instant> = None;
+
+        while let Some(chunk) = chunk_rx.recv().await {
+            forwarded_count += 1;
+            match chunk {
+                StreamChunk::Content { text, item_id } => {
+                    if first_content_time.is_none() {
+                        first_content_time = Some(std::time::Instant::now());
+                    }
+                    total_content_len += text.len();
+                    debug!(
+                        "Forwarding Action::ResponseChunk (len={}, total={})",
+                        text.len(),
+                        total_content_len
+                    );
+                    if tx.send(Action::ResponseChunk { text, item_id }).is_err() {
+                        warn!("Failed to forward ResponseChunk: receiver dropped");
+                        return;
+                    }
+                }
+                StreamChunk::Thinking { text, item_id } => {
+                    if first_content_time.is_none() {
+                        first_content_time = Some(std::time::Instant::now());
+                    }
+                    debug!("Forwarding Action::ThinkingChunk (len={})", text.len());
+                    if tx.send(Action::ThinkingChunk { text, item_id }).is_err() {
+                        warn!("Failed to forward ThinkingChunk: receiver dropped");
+                        return;
+                    }
+                }
+                StreamChunk::ToolCall(tc) => {
+                    debug!("Forwarding ToolCall: {} (call_id={})", tc.name, tc.call_id);
+                    if tx.send(Action::ToolCallReceived(tc)).is_err() {
+                        warn!("Failed to forward ToolCall: receiver dropped");
+                        return;
+                    }
+                }
+                StreamChunk::Completed(provider_stats) => {
+                    let duration_ms = request_start.elapsed().as_millis() as u64;
+                    let ttft_ms =
+                        first_content_time.map(|t| (t - request_start).as_millis() as u64);
+
+                    // Enrich provider stats with client-side timing
+                    let mut stats = provider_stats.unwrap_or_default();
+                    stats.ttft_ms = ttft_ms;
+                    stats.generation_duration_ms = Some(duration_ms);
+                    if let Some(output_tokens) = stats.output_tokens
+                        && duration_ms > 0
+                    {
+                        stats.tokens_per_sec =
+                            Some(output_tokens as f32 / (duration_ms as f32 / 1000.0));
+                    }
+
+                    debug!(
+                        "Stream completed: ttft={}ms, duration={}ms, tok/s={:?}",
+                        ttft_ms.unwrap_or(0),
+                        duration_ms,
+                        stats.tokens_per_sec
+                    );
+
+                    info!(
+                        "Forwarding complete: {} actions, {} content bytes",
+                        forwarded_count, total_content_len
+                    );
+                    if tx.send(Action::ResponseDone(Some(stats))).is_err() {
+                        warn!("Failed to send ResponseDone: receiver dropped");
+                    }
+                    return;
+                }
+            }
+        }
+
+        // Fallback: channel closed without a Completed event
+        info!(
+            "Stream channel closed: {} actions, {} content bytes",
+            forwarded_count, total_content_len
+        );
+        if tx.send(Action::ResponseDone(None)).is_err() {
+            warn!("Failed to send ResponseDone: receiver dropped");
+        }
+    });
+
+    vec![stream_handle.abort_handle(), forward_handle.abort_handle()]
+}
+
+/// Spawns a background task to fetch models from all configured providers.
+///
+/// Runs OpenRouter and LM Studio fetches concurrently via `tokio::join!`.
+/// LM Studio has a 3s timeout so it won't block if the server isn't running.
+/// Results are deduped against pinned models in `ModelPickerState::set_fetched_models()`.
+pub fn spawn_model_fetch(app: &App, tx: mpsc::Sender<Action>) {
+    let openrouter_base_url = app.openrouter_base_url.clone();
+    let openrouter_api_key = app.openrouter_api_key.clone();
+    let lmstudio_base_url = app.lmstudio_base_url.clone();
+
+    tokio::spawn(async move {
+        let (or_result, lms_result) = tokio::join!(
+            async {
+                match openrouter_api_key {
+                    Some(ref key) => {
+                        model_discovery::fetch_openrouter_models(&openrouter_base_url, key).await
+                    }
+                    None => {
+                        warn!("No OpenRouter API key — skipping model fetch");
+                        Ok(Vec::new())
+                    }
+                }
+            },
+            async { model_discovery::fetch_lmstudio_models(&lmstudio_base_url).await }
+        );
+
+        let mut all_models = Vec::new();
+
+        match or_result {
+            Ok(models) => all_models.extend(models),
+            Err(e) => warn!("OpenRouter model fetch failed: {}", e),
+        }
+
+        match lms_result {
+            Ok(models) => all_models.extend(models),
+            Err(e) => debug!(
+                "LM Studio model fetch failed (server may not be running): {}",
+                e
+            ),
+        }
+
+        info!("Model fetch complete: {} total models", all_models.len());
+
+        if tx.send(Action::ModelsFetched(all_models)).is_err() {
+            warn!("Failed to send ModelsFetched: receiver dropped");
+        }
+    });
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,3 +1,13 @@
+//! # UI Layout & Rendering
+//!
+//! Top-level `draw_ui` function that composes all components into a frame.
+//!
+//! **Layout:** title bar (1 line) + main area (flex) + input box (3-7 lines).
+//!
+//! **Rendering order:** Main area renders first so `MessageList::render` can
+//! update the layout cache before `hit_test_message` needs it. Then title bar,
+//! input box, and finally overlays (session manager, model picker) on top.
+
 use crate::core::state::App;
 use crate::tui::TuiState;
 use crate::tui::component::Component;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -30,9 +30,9 @@ pub fn draw_ui(frame: &mut Frame, app: &App, tui: &mut TuiState, spinner_frame: 
 
     // 1. Render Main Area (MessageList or Error)
     // Rendered first so MessageList::render updates layout cache in TuiState.
-    if let Some(error_msg) = &app.error {
+    if let Some(error_msg) = &app.session.error {
         draw_error_view(frame, main_area, error_msg);
-    } else if !app.context.has_visible_messages() {
+    } else if !app.session.context.has_visible_messages() {
         // Render Landing Page
         let mut landing = crate::tui::components::LandingPage::new(spinner_frame);
         landing.render(frame, main_area);
@@ -40,11 +40,11 @@ pub fn draw_ui(frame: &mut Frame, app: &App, tui: &mut TuiState, spinner_frame: 
         // Create MessageList wrapper around mutable persistent state
         let mut message_list = MessageList::new(
             &mut tui.message_list, // &mut MessageListState
-            &app.context,
-            app.is_loading,
+            &app.session.context,
+            app.session.is_loading,
             tui.pulse_value,
             spinner_frame,
-            &app.message_stats,
+            &app.session.message_stats,
         );
         // Mutable render call updates layout cache and renders to scroll view
         message_list.render(frame, main_area);
@@ -54,10 +54,10 @@ pub fn draw_ui(frame: &mut Frame, app: &App, tui: &mut TuiState, spinner_frame: 
     let mut title_bar = TitleBar::new(
         &app.model_name,
         &app.provider_name,
-        app.is_loading,
+        app.session.is_loading,
         spinner_frame,
-        &app.session_title,
-        app.session_total_tokens,
+        &app.session.session_title,
+        app.session.session_total_tokens,
     );
     title_bar.render(frame, title_area);
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -30,15 +30,9 @@ pub fn draw_ui(frame: &mut Frame, app: &App, tui: &mut TuiState, spinner_frame: 
 
     // 1. Render Main Area (MessageList or Error)
     // Rendered first so MessageList::render updates layout cache in TuiState.
-
-    // Check if there are any user-visible messages (User or Model)
-    let has_visible_messages = app.context.items.iter().any(|item|
-        matches!(item, crate::inference::ContextItem::Message(seg) if matches!(seg.source, crate::inference::Source::User | crate::inference::Source::Model))
-    );
-
     if let Some(error_msg) = &app.error {
         draw_error_view(frame, main_area, error_msg);
-    } else if !has_visible_messages {
+    } else if !app.context.has_visible_messages() {
         // Render Landing Page
         let mut landing = crate::tui::components::LandingPage::new(spinner_frame);
         landing.render(frame, main_area);


### PR DESCRIPTION
## What

Decomposes the monolithic TUI event loop (`mod.rs`, 600+ lines) into four focused modules:

- `mod.rs` (225 lines) - Terminal lifecycle, state init, event loop orchestration
- `handlers.rs` (387 lines + tests) - Event dispatch, mode switching, navigation
- `tasks.rs` - Async task spawning (requests, tool execution, model fetch)
- `ui.rs` - Rendering (already existed, unchanged)

Also routes state mutations (effort cycling, model switching, session management) through the `core::action::update()` reducer instead of mutating `App` directly in the TUI.

## Why

`mod.rs` had grown into a god-module that mixed terminal setup, event dispatch, state mutation, and async spawning. This made it hard to test: the event handling logic was entangled with terminal I/O. The reducer pattern was partially adopted but inconsistent; some actions went through `update()` while others mutated state inline.

The decomposition makes handler logic unit-testable without a terminal, keeps the orchestrator minimal, and ensures all domain state flows through the reducer.

## How

1. Extracted `SessionState` from `App` for clean session resets
2. Routed effort, model switching, and session ops through the reducer (with 24 tests)
3. Extracted background task spawners into `tasks.rs`
4. Extracted event dispatch into `handlers.rs`
5. Added 19 handler tests covering dispatch, mode switching, navigation, and background actions

## Design Decisions

**Why a reducer (`update()`) instead of methods on `App`?**
The reducer pattern (`State + Action -> Effect`) keeps state transitions explicit and testable in isolation. The `Effect` enum tells the caller what side effect to perform (spawn a request, save session, rebuild provider, quit) without the reducer needing to know how. This means `action.rs` has zero I/O dependencies and tests run in microseconds.

**Why `handlers.rs` takes `&mut App` + `&mut TuiState` instead of owning state?**
The event loop in `mod.rs` needs mutable access to both between handler calls (e.g., syncing `InputBox.effort` with `App.effort` each frame). Passing references keeps the orchestrator in control of the borrow scope. The tradeoff is verbose function signatures, but it avoids the "who owns what" confusion that would come from handing state to handlers.

**Why `Effect::RebuildProvider` exists separately from `Effect::SpawnRequest`?**
Model switching requires reconstructing the provider (different API endpoint/auth), which needs `ResolvedConfig` - something the core reducer shouldn't know about. So the reducer signals "provider needs rebuilding" and the TUI layer handles it with config access. This keeps the config dependency out of core.

**Why `SessionState` was extracted from `App`?**
Session resets (new session, load session, delete active session) were doing field-by-field clearing which was fragile - easy to forget a field. `SessionState::new()` gives a single reset point. `App` holds cross-session state (provider, model, registry), `SessionState` holds per-conversation state (context, loading, tool calls).

## What's Not Tested (and Why)

- `handle_session_event` - calls `session::load_session()` / `session::load_index()` which do file I/O
- `handle_model_picker_event` select path - calls `build_provider()` which needs real config
- Mouse handlers - depend on layout state produced by rendering
- `tasks.rs` - every function spawns tokio tasks needing async runtime + mock providers; thin wrappers, not worth the setup cost yet

These boundaries are where unit tests stop being useful and integration/manual testing takes over. If any of these grow complex logic, extract the logic into a testable pure function first.

## Test Plan

- [x] `cargo test` - 261 unit + 8 integration tests pass
- [x] `cargo clippy` - zero warnings
- [x] `cargo fmt --check` - formatted